### PR TITLE
Add `exodus-bundler` as a secondary entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     entry_points={
         'console_scripts': [
             'exodus = exodus_bundler.cli:main',
+            'exodus-bundler = exodus_bundler.cli:main',
         ],
     },
 )


### PR DESCRIPTION
This allows either `exodus` or `exodus-bundler` to be used as an entry point for the command-line interface.


Closes #2
