### PR TITLE
Make `ldd` output handling more robust

### DIFF
--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -174,11 +174,13 @@ def find_all_library_dependencies(ldd, binary):
 
 def find_direct_library_dependencies(ldd, binary):
     """Finds the libraries that a binary directly links to."""
-    return parse_ldd_output(run_ldd(ldd, binary))
+    return parse_dependencies_from_ldd_output(run_ldd(ldd, binary))
 
 
 def parse_dependencies_from_ldd_output(content):
-    """Takes in the text output of `ldd` and parsed the dependencies."""
+    """Takes the output of `ldd` as a string or list of lines and parses the dependencies."""
+    if type(content) == str:
+        content = content.split('\n')
     matches = filter(None, (re.search('=>\s*([^(]*?)\s*\(', line) for line in content))
     return [match.group(1) for match in matches]
 

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -174,7 +174,12 @@ def find_all_library_dependencies(ldd, binary):
 
 def find_direct_library_dependencies(ldd, binary):
     """Finds the libraries that a binary directly links to."""
-    matches = filter(None, (re.search('=>\s*([^(]*?)\s*\(', line) for line in run_ldd(ldd, binary)))
+    return parse_ldd_output(run_ldd(ldd, binary))
+
+
+def parse_dependencies_from_ldd_output(content):
+    """Takes in the text output of `ldd` and parsed the dependencies."""
+    matches = filter(None, (re.search('=>\s*([^(]*?)\s*\(', line) for line in content))
     return [match.group(1) for match in matches]
 
 

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -181,8 +181,15 @@ def parse_dependencies_from_ldd_output(content):
     """Takes the output of `ldd` as a string or list of lines and parses the dependencies."""
     if type(content) == str:
         content = content.split('\n')
-    matches = filter(None, (re.search('=>\s*([^(]*?)\s*\(', line) for line in content))
-    return [match.group(1) for match in matches]
+
+    dependencies = []
+    for line in content:
+        match = re.search('=>\s*(/.*?)\s*\(', line)
+        match = match or re.search('\s*(/.*?)\s*\(', line)
+        if match:
+            dependencies.append(match.group(1))
+
+    return dependencies
 
 
 def resolve_binary(binary):

--- a/tests/data/ldd-output/htop-amazon-linux-dependencies.txt
+++ b/tests/data/ldd-output/htop-amazon-linux-dependencies.txt
@@ -1,0 +1,6 @@
+/lib64/libncursesw.so.5
+/lib64/libtinfo.so.5
+/lib64/libm.so.6
+/lib64/libgcc_s.so.1
+/lib64/libc.so.6
+/lib64/ld-linux-x86-64.so.2

--- a/tests/data/ldd-output/htop-amazon-linux-dependencies.txt
+++ b/tests/data/ldd-output/htop-amazon-linux-dependencies.txt
@@ -3,4 +3,5 @@
 /lib64/libm.so.6
 /lib64/libgcc_s.so.1
 /lib64/libc.so.6
+/lib64/libdl.so.2
 /lib64/ld-linux-x86-64.so.2

--- a/tests/data/ldd-output/htop-amazon-linux.txt
+++ b/tests/data/ldd-output/htop-amazon-linux.txt
@@ -1,0 +1,8 @@
+	linux-vdso.so.1 =>  (0x00007ffc7ff9e000)
+	libncursesw.so.5 => /lib64/libncursesw.so.5 (0x00007fce6f039000)
+	libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00007fce6ee18000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fce6eb16000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fce6e900000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fce6e53c000)
+	libdl.so.2 => /lib64/libdl.so.2 (0x00007fce6e338000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fce6f26e000)

--- a/tests/data/ldd-output/htop-arch-dependencies.txt
+++ b/tests/data/ldd-output/htop-arch-dependencies.txt
@@ -1,0 +1,4 @@
+/usr/lib/libncursesw.so.6
+/usr/lib/libm.so.6
+/usr/lib/libc.so.6
+/usr/lib64/ld-linux-x86-64.so.2

--- a/tests/data/ldd-output/htop-arch.txt
+++ b/tests/data/ldd-output/htop-arch.txt
@@ -1,0 +1,5 @@
+	linux-vdso.so.1 (0x00007ffd7abf3000)
+	libncursesw.so.6 => /usr/lib/libncursesw.so.6 (0x00007fbfc45be000)
+	libm.so.6 => /usr/lib/libm.so.6 (0x00007fbfc4272000)
+	libc.so.6 => /usr/lib/libc.so.6 (0x00007fbfc3ebb000)
+	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fbfc4a58000)

--- a/tests/data/ldd-output/htop-ubuntu-14.04-dependencies.txt
+++ b/tests/data/ldd-output/htop-ubuntu-14.04-dependencies.txt
@@ -1,0 +1,6 @@
+/lib/x86_64-linux-gnu/libncursesw.so.5
+/lib/x86_64-linux-gnu/libtinfo.so.5
+/lib/x86_64-linux-gnu/libm.so.6
+/lib/x86_64-linux-gnu/libc.so.6
+/lib/x86_64-linux-gnu/libdl.so.2
+/lib64/ld-linux-x86-64.so.2

--- a/tests/data/ldd-output/htop-ubuntu-14.04.txt
+++ b/tests/data/ldd-output/htop-ubuntu-14.04.txt
@@ -1,0 +1,7 @@
+	linux-vdso.so.1 =>  (0x00007ffe625eb000)
+	libncursesw.so.5 => /lib/x86_64-linux-gnu/libncursesw.so.5 (0x00007f18b88a9000)
+	libtinfo.so.5 => /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007f18b8680000)
+	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f18b837a000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f18b7fb2000)
+	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f18b7dae000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f18b8add000)


### PR DESCRIPTION
This adds a fallback regex for extracting libraries, makes the original regex more robust, and adds tests for `ldd` output on Amazon Linux, Arch Linux, and Ubuntu.

Closes #5
