### PR TITLE
Improve error handling

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -3,7 +3,7 @@ Please include the following information if you're reporting an issue.
 - Which operating system you're using.
 - Which Python version.
 - Which exodus package version.
-- The command that you're running.
+- The command that you're running (please include the `--verbose` flag so that the stack trace is included).
 - The full output of the command.
 - Where `$BINARY` is the name of the executable that you're trying to bundle, include the outputs of the following:
     - `which $BINARY`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
         <img src="https://img.shields.io/circleci/project/github/Intoli/exodus/master.svg"
             alt="Build Status"></a>
     <a href="https://circleci.com/gh/Intoli/exodus/tree/master">
-        <img src="https://img.shields.io/badge/coverage-92.09%25-lightgrey.svg"
+        <img src="https://img.shields.io/badge/coverage-94.44%25-lightgrey.svg"
             alt="Coverage"></a>
     <a href="https://github.com/Intoli/exodus/blob/master/LICENSE.md">
         <img src="https://img.shields.io/pypi/l/exodus-bundler.svg"

--- a/development-requirements.txt
+++ b/development-requirements.txt
@@ -4,7 +4,6 @@ m2r>=0.1.12
 pluggy==0.5.2
 py==1.4.34
 pytest==3.2.3
-pytest-console-scripts==0.1.3
 pytest-sugar==0.9.0
 pytest-watch==4.1.0
 six==1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ ignore = E128
 max-line-length = 100
 
 [tool:pytest]
-script_launch_mode = subprocess
 norecursedirs =
     .git
     .tox

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -165,6 +165,13 @@ def create_unpackaged_bundle(executables, rename=[], ldd='ldd'):
         raise
 
 
+def detect_elf_binary(filename):
+    """Returns `True` if a file has an ELF header."""
+    with open(filename, 'rb') as f:
+        first_four_bytes = f.read(4)
+    return first_four_bytes == b'\x7fELF'
+
+
 def find_all_library_dependencies(ldd, binary):
     """Finds all libraries that a binary directly or indirectly links to."""
     all_dependencies = set()

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -97,7 +97,7 @@ def create_unpackaged_bundle(executables, rename=[], ldd='ldd'):
             'More renamed options were included than executables.'
         # Pad the rename's so that they have the same length for the `zip()` call.
         rename = rename + [None for i in range(len(executables) - len(rename))]
-        for name, executable in zip(rename, executables):
+        for name, executable in zip(rename, map(resolve_binary, executables)):
             # Make the bundle subdirectories for this executable.
             binary_name = (name or os.path.basename(executable)).replace(os.sep, '')
             binary_hash = sha256_hash(executable)

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -12,6 +12,8 @@ import tempfile
 from subprocess import PIPE
 from subprocess import Popen
 
+from exodus_bundler.errors import InvalidElfBinaryError
+from exodus_bundler.errors import MissingFileError
 from exodus_bundler.launchers import CompilerNotFoundError
 from exodus_bundler.launchers import construct_bash_launcher
 from exodus_bundler.launchers import construct_binary_launcher
@@ -20,12 +22,6 @@ from exodus_bundler.templating import render_template_file
 
 
 logger = logging.getLogger(__name__)
-
-
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
 
 
 def create_bundle(executables, output, tarball=False, rename=[], ldd='ldd'):
@@ -101,7 +97,7 @@ def create_unpackaged_bundle(executables, rename=[], ldd='ldd'):
             'More renamed options were included than executables.'
         # Pad the rename's so that they have the same length for the `zip()` call.
         rename = rename + [None for i in range(len(executables) - len(rename))]
-        for name, executable in zip(rename, map(resolve_binary, executables)):
+        for name, executable in zip(rename, executables):
             # Make the bundle subdirectories for this executable.
             binary_name = (name or os.path.basename(executable)).replace(os.sep, '')
             binary_hash = sha256_hash(executable)
@@ -167,8 +163,12 @@ def create_unpackaged_bundle(executables, rename=[], ldd='ldd'):
 
 def detect_elf_binary(filename):
     """Returns `True` if a file has an ELF header."""
+    if not os.path.exists(filename):
+        raise MissingFileError('The "%s" file was not found.' % filename)
+
     with open(filename, 'rb') as f:
         first_four_bytes = f.read(4)
+
     return first_four_bytes == b'\x7fELF'
 
 
@@ -207,23 +207,31 @@ def parse_dependencies_from_ldd_output(content):
 
 def resolve_binary(binary):
     """Attempts to find the absolute path to the binary."""
-    if not os.path.exists(binary):
+    absolute_binary_path = os.path.normpath(os.path.abspath(binary))
+    if not os.path.exists(absolute_binary_path):
         for path in os.getenv('PATH', '').split(os.pathsep):
             absolute_binary_path = os.path.normpath(os.path.abspath(os.path.join(path, binary)))
             if os.path.exists(absolute_binary_path):
-                binary = absolute_binary_path
-    return binary
+                break
+        else:
+            raise MissingFileError('The "%s" binary could not be found in $PATH.')
+    return absolute_binary_path
 
 
 def run_ldd(ldd, binary):
     """Runs `ldd` and gets the combined stdout/stderr output as a list of lines."""
-    if not os.path.exists(binary):
-        raise FileNotFoundError('"%s" is not a file.')
+    if not detect_elf_binary(resolve_binary(binary)):
+        raise InvalidElfBinaryError('The "%s" file is not a binary ELF file.' % binary)
+
     process = Popen([ldd, binary], stdout=PIPE, stderr=PIPE)
     stdout, stderr = process.communicate()
     return stdout.decode('utf-8').split('\n') + stderr.decode('utf-8').split('\n')
 
 
 def sha256_hash(filename):
+    """Produces an SHA-256 hash of a file."""
+    if not os.path.exists(filename):
+        raise MissingFileError('The "%s" file was not found.' % filename)
+
     with open(filename, 'rb') as f:
         return hashlib.sha256(f.read()).hexdigest()

--- a/src/exodus_bundler/cli.py
+++ b/src/exodus_bundler/cli.py
@@ -4,6 +4,10 @@ import sys
 
 from exodus_bundler import root_logger
 from exodus_bundler.bundling import create_bundle
+from exodus_bundler.errors import FatalError
+
+
+logger = logging.getLogger(__name__)
 
 
 def parse_args(args=None, namespace=None):
@@ -110,4 +114,9 @@ def main(args=None, namespace=None):
     configure_logging(quiet=quiet, verbose=verbose, suppress_stdout=suppress_stdout)
 
     # Create the bundle with all of the arguments.
-    create_bundle(**args)
+    try:
+        create_bundle(**args)
+    except FatalError as fatal_error:
+        logger.error(str(fatal_error))
+        logger.error('Fatal error encountered, exiting.')
+        sys.exit(1)

--- a/src/exodus_bundler/cli.py
+++ b/src/exodus_bundler/cli.py
@@ -117,6 +117,6 @@ def main(args=None, namespace=None):
     try:
         create_bundle(**args)
     except FatalError as fatal_error:
-        logger.error(str(fatal_error))
         logger.error('Fatal error encountered, exiting.')
+        logger.error(fatal_error, exc_info=verbose)
         sys.exit(1)

--- a/src/exodus_bundler/errors.py
+++ b/src/exodus_bundler/errors.py
@@ -1,0 +1,13 @@
+class FatalError(Exception):
+    """Base class for exceptions that should terminate program execution."""
+    pass
+
+
+class InvalidElfBinaryError(FatalError):
+    """Signifies that a file was expected to be an ELF binary, but wasn't."""
+    pass
+
+
+class MissingFileError(FatalError):
+    """Signifies that a file was not found."""
+    pass

--- a/tests/test_bundling.py
+++ b/tests/test_bundling.py
@@ -6,6 +6,7 @@ from subprocess import Popen
 import pytest
 
 from exodus_bundler.bundling import create_unpackaged_bundle
+from exodus_bundler.bundling import detect_elf_binary
 from exodus_bundler.bundling import find_all_library_dependencies
 from exodus_bundler.bundling import find_direct_library_dependencies
 from exodus_bundler.bundling import parse_dependencies_from_ldd_output
@@ -38,6 +39,11 @@ def test_create_unpackaged_bundle():
     finally:
         assert root_directory.startswith('/tmp/')
         shutil.rmtree(root_directory)
+
+
+def test_detect_elf_binary():
+    assert detect_elf_binary(executable), 'The `fizz-buzz` file should be an ELF binary.'
+    assert not detect_elf_binary(ldd), 'The `ldd` file should be a shell script.'
 
 
 def test_find_all_library_dependencies():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,19 +89,21 @@ def test_writing_bundle_to_disk(script_runner):
             os.unlink(filename)
 
 
-def test_writing_bundle_to_stdout(script_runner):
+def test_writing_bundle_to_stdout():
     args = ['--ldd', ldd_path, '--output', '-', fizz_buzz_path]
-    result = script_runner.run('exodus', *args)
-    assert result.stdout.startswith('#! /bin/bash'), result.stderr
+    returncode, stdout, stderr = run_exodus(args)
+    assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+    assert stdout.startswith('#! /bin/bash'), stderr
 
 
-def test_writing_tarball_to_disk(script_runner):
+def test_writing_tarball_to_disk():
     f, filename = tempfile.mkstemp(suffix='.tgz')
     os.close(f)
     args = ['--ldd', ldd_path, '--output', filename, '--tarball', fizz_buzz_path]
     try:
-        result = script_runner.run('exodus', *args)
-        assert tarfile.is_tarfile(filename), result.stderr
+        returncode, stdout, stderr = run_exodus(args)
+        assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+        assert tarfile.is_tarfile(filename), stderr
         with tarfile.open(filename, mode='r:gz') as f_in:
             assert 'exodus/bin/fizz-buzz' in f_in.getnames()
     finally:
@@ -109,10 +111,10 @@ def test_writing_tarball_to_disk(script_runner):
             os.unlink(filename)
 
 
-def test_writing_tarball_to_stdout(script_runner):
+def test_writing_tarball_to_stdout():
     args = ['--ldd', ldd_path, '--output', '-', '--tarball', fizz_buzz_path]
-    process = subprocess.Popen(['exodus'] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate()
+    returncode, stdout, stderr = run_exodus(args, universal_newlines=False)
+    assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
     stream = io.BytesIO(stdout)
     with tarfile.open(fileobj=stream, mode='r:gz') as f:
         assert 'exodus/bin/fizz-buzz' in f.getnames(), stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,14 @@ ldd_path = os.path.join(chroot, 'bin', 'ldd')
 fizz_buzz_path = os.path.join(chroot, 'bin', 'fizz-buzz')
 
 
+def run_exodus(args, **options):
+    options['universal_newlines'] = options.get('universal_newlines', True)
+    process = subprocess.Popen(
+        ['exodus'] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **options)
+    stdout, stderr = process.communicate()
+    return process.returncode, stdout, stderr
+
+
 def test_logging_outputs(capsys):
     # There should be no output before configuring the logger.
     logger.error('error')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,19 @@ def test_logging_outputs(capsys):
     assert all(output not in err for output in ('info', 'debug'))
 
 
+def test_missing_binary(capsys):
+    # Without the --verbose flag.
+    command = 'this-is-almost-definitely-not-going-to-be-a-command-anywhere'
+    returncode, stdout, stderr = run_exodus([command])
+    assert returncode != 0, 'Running exodus should have failed.'
+    assert 'Traceback' not in stderr, 'Traceback should not be included without the --verbose flag.'
+
+    # With the --verbose flag.
+    returncode, stdout, stderr = run_exodus(['--verbose', command])
+    assert returncode != 0, 'Running exodus should have failed.'
+    assert 'Traceback' in stderr, 'Traceback should be included with the --verbose flag.'
+
+
 def test_required_argument():
     with pytest.raises(SystemExit):
         parse_args([])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,15 +75,16 @@ def test_quiet_and_verbose_flags():
     assert result['verbose'] and not result['quiet']
 
 
-def test_writing_bundle_to_disk(script_runner):
+def test_writing_bundle_to_disk():
     f, filename = tempfile.mkstemp(suffix='.sh')
     os.close(f)
     args = ['--ldd', ldd_path, '--output', filename, fizz_buzz_path]
     try:
-        result = script_runner.run('exodus', *args)
+        returncode, stdout, stderr = run_exodus(args)
+        assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
         with open(filename, 'rb') as f_in:
             first_line = f_in.readline().strip()
-        assert first_line == b'#! /bin/bash', result.stderr
+        assert first_line == b'#! /bin/bash', stderr
     finally:
         if os.path.exists(filename):
             os.unlink(filename)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ passenv =
 usedevelop = false
 deps =
     pytest
-    pytest-console-scripts
     pytest-sugar
     pytest-travis-fold
     pytest-cov


### PR DESCRIPTION
This adds a `FatalError` base class and a few other derived classes that are thrown when various expected things go wrong (not an ELF binary, file not found, *etc.). These are caught by the CLI and logged appropriately to stderr (with the stack trace if the `--verbose` flag is included). We can add more error types over time as we see fit, but this should handle the most common issues that people will encounter.


Closes #9
