### PR TITLE
Improve library conflict handling

### DIFF
--- a/src/exodus_bundler/errors.py
+++ b/src/exodus_bundler/errors.py
@@ -8,6 +8,12 @@ class InvalidElfBinaryError(FatalError):
     pass
 
 
+class LibraryConflictError(FatalError):
+    """Signifies that two libraries with the same filename,
+    but different file contents were encounterer."""
+    pass
+
+
 class MissingFileError(FatalError):
     """Signifies that a file was not found."""
     pass


### PR DESCRIPTION
This adds a new `LibraryConflictError` to be used instead of the assertion, makes the error message more informative, and fixes the logic surrounding which duplicates are issues. Any filename conflict had previously caused an error, but it's really only a fatal issue if *both* the filename and file content conflict.


Connects #15
