### PR TITLE
Add support for busybox tar

### DIFF
--- a/src/exodus_bundler/templates/install-bundle-noninteractive.sh
+++ b/src/exodus_bundler/templates/install-bundle-noninteractive.sh
@@ -11,7 +11,7 @@ echo "Installing executable bundle in \"${output_directory}\"..."
 mkdir -p ${output_directory} 2> /dev/null
 
 # Actually perform the extraction.
-base64 -d << "END_OF_FILE" | tar -C "${output_directory}" --strip 1 --no-same-owner --preserve-permissions -zvxf - > /dev/null
+base64 -d << "END_OF_FILE" | tar -C "${output_directory}" --strip-components 1 --no-same-owner --preserve-permissions -zvxf - > /dev/null
 {{base64_encoded_tarball}}
 END_OF_FILE
 if [ $? -eq 0 ]; then

--- a/src/exodus_bundler/templates/install-bundle-noninteractive.sh
+++ b/src/exodus_bundler/templates/install-bundle-noninteractive.sh
@@ -11,7 +11,7 @@ echo "Installing executable bundle in \"${output_directory}\"..."
 mkdir -p ${output_directory} 2> /dev/null
 
 # Actually perform the extraction.
-base64 -d << "END_OF_FILE" | tar -C "${output_directory}" --strip-components 1 --no-same-owner --preserve-permissions -zvxf - > /dev/null
+base64 -d << "END_OF_FILE" | tar -C "${output_directory}" --strip-components 1 --no-same-owner -p -zvxf - > /dev/null
 {{base64_encoded_tarball}}
 END_OF_FILE
 if [ $? -eq 0 ]; then

--- a/src/exodus_bundler/templates/install-bundle.sh
+++ b/src/exodus_bundler/templates/install-bundle.sh
@@ -23,7 +23,7 @@ mkdir -p ${output_directory} 2> /dev/null
 
 # Actually perform the extraction.
 begin_tarball_line=$((1 + $(grep --text --line-number '^BEGIN-TARBALL$' $0 | cut -d ':' -f 1)))
-tail -n +$begin_tarball_line "$0" | tar -C "${output_directory}" --strip-components 1 --no-same-owner --preserve-permissions -zvxf - > /dev/null
+tail -n +$begin_tarball_line "$0" | tar -C "${output_directory}" --strip-components 1 --no-same-owner -p -zvxf - > /dev/null
 if [ $? -eq 0 ]; then
     echo "Successfully installed, be sure to add "${output_directory}/bin" to your \$PATH."
     exit 0

--- a/src/exodus_bundler/templates/install-bundle.sh
+++ b/src/exodus_bundler/templates/install-bundle.sh
@@ -23,7 +23,7 @@ mkdir -p ${output_directory} 2> /dev/null
 
 # Actually perform the extraction.
 begin_tarball_line=$((1 + $(grep --text --line-number '^BEGIN-TARBALL$' $0 | cut -d ':' -f 1)))
-tail -n +$begin_tarball_line "$0" | tar -C "${output_directory}" --strip 1 --no-same-owner --preserve-permissions -zvxf - > /dev/null
+tail -n +$begin_tarball_line "$0" | tar -C "${output_directory}" --strip-components 1 --no-same-owner --preserve-permissions -zvxf - > /dev/null
 if [ $? -eq 0 ]; then
     echo "Successfully installed, be sure to add "${output_directory}/bin" to your \$PATH."
     exit 0


### PR DESCRIPTION
This modifies the installation script templates to using `tar` arguments that should be compatible with both GNU and BusyBox implementations. Some of the BusyBox options aren't documented in the help pages, but can be seen in [the source code](https://git.busybox.net/busybox/tree/archival/tar.c).


Closes #20
