### PR TITLE
Allow piping in strace outputs to add additional dependencies

### DIFF
--- a/src/exodus_bundler/cli.py
+++ b/src/exodus_bundler/cli.py
@@ -5,6 +5,7 @@ import sys
 from exodus_bundler import root_logger
 from exodus_bundler.bundling import create_bundle
 from exodus_bundler.errors import FatalError
+from exodus_bundler.input_parsing import extract_filenames
 
 
 logger = logging.getLogger(__name__)
@@ -127,7 +128,7 @@ def main(args=None, namespace=None):
 
     # Allow piping in additional files.
     if not sys.stdin.isatty():
-        args['add'] += sys.stdin.read().splitlines()
+        args['add'] += extract_filenames(sys.stdin.read())
 
     # Create the bundle with all of the arguments.
     try:

--- a/src/exodus_bundler/cli.py
+++ b/src/exodus_bundler/cli.py
@@ -5,7 +5,7 @@ import sys
 from exodus_bundler import root_logger
 from exodus_bundler.bundling import create_bundle
 from exodus_bundler.errors import FatalError
-from exodus_bundler.input_parsing import extract_filenames
+from exodus_bundler.input_parsing import extract_paths
 
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,7 @@ def main(args=None, namespace=None):
 
     # Allow piping in additional files.
     if not sys.stdin.isatty():
-        args['add'] += extract_filenames(sys.stdin.read())
+        args['add'] += extract_paths(sys.stdin.read())
 
     # Create the bundle with all of the arguments.
     try:

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -39,3 +39,12 @@ def extract_filenames(content):
     strace_mode = extract_exec_filename(lines[0]) is not None
     if not strace_mode:
         return lines
+
+    # Extract files from `open()`, `openat()`, and `exec()` calls.
+    filenames = []
+    for line in lines:
+        filename = extract_exec_filename(line)
+        if filename:
+            filenames.append(filename)
+
+    return filenames

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -22,6 +22,23 @@ def extract_exec_path(line):
     return None
 
 
+def extract_open_path(line):
+    """Parse a line of strace output and returns the file being opened."""
+    for prefix in ['openat(AT_FDCWD, "', 'open("']:
+        if line.startswith(prefix):
+            parts = line[len(prefix):].split('", ')
+            if len(parts) != 2:
+                continue
+            if 'ENOENT' in parts[1]:
+                continue
+            if 'O_RDONLY' not in parts[1]:
+                continue
+            if 'O_DIRECTORY' in parts[1]:
+                continue
+            return parts[0]
+    return None
+
+
 def extract_paths(content):
     """Parses paths from a piped input.
 

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -1,3 +1,27 @@
+exec_methods = [
+    'execve',
+    'exec',
+    'execl',
+    'execlp',
+    'execle',
+    'execv',
+    'execvp',
+    'execvpe',
+]
+
+
+def extract_exec_filename(line):
+    """Parse a line of strace output and returns the file being executed."""
+    for method in exec_methods:
+        prefix = method + '("'
+        if line.startswith(prefix):
+            line = line[len(prefix):]
+            parts = line.split('", ')
+            if len(parts) > 1:
+                return parts[0]
+    return None
+
+
 def extract_filenames(content):
     """Parses filenames from a piped input.
 

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -1,0 +1,16 @@
+def extract_filenames(content):
+    """Parses filenames from a piped input.
+
+    Args:
+        content (str): The raw input, can be either a list of files,
+            or the output of the strace command.
+    Returns:
+        A list of filenames.
+    """
+    lines = [line.strip() for line in content.splitlines() if len(line.strip())]
+    if not len(lines):
+        return lines
+
+    strace_mode = lines[0].startswith('execve("')
+    if not strace_mode:
+        return lines

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -10,7 +10,7 @@ exec_methods = [
 ]
 
 
-def extract_exec_filename(line):
+def extract_exec_path(line):
     """Parse a line of strace output and returns the file being executed."""
     for method in exec_methods:
         prefix = method + '("'
@@ -22,29 +22,29 @@ def extract_exec_filename(line):
     return None
 
 
-def extract_filenames(content):
-    """Parses filenames from a piped input.
+def extract_paths(content):
+    """Parses paths from a piped input.
 
     Args:
         content (str): The raw input, can be either a list of files,
             or the output of the strace command.
     Returns:
-        A list of filenames.
+        A list of paths.
     """
     lines = [line.strip() for line in content.splitlines() if len(line.strip())]
     if not len(lines):
         return lines
 
     # The strace output will start with the exec call of its argument.
-    strace_mode = extract_exec_filename(lines[0]) is not None
+    strace_mode = extract_exec_path(lines[0]) is not None
     if not strace_mode:
         return lines
 
     # Extract files from `open()`, `openat()`, and `exec()` calls.
-    filenames = []
+    paths = []
     for line in lines:
-        filename = extract_exec_filename(line)
-        if filename:
-            filenames.append(filename)
+        path = extract_exec_path(line)
+        if path:
+            paths.append(path)
 
-    return filenames
+    return paths

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -60,7 +60,7 @@ def extract_paths(content):
     # Extract files from `open()`, `openat()`, and `exec()` calls.
     paths = []
     for line in lines:
-        path = extract_exec_path(line)
+        path = extract_exec_path(line) or extract_open_path(line)
         if path:
             paths.append(path)
 

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -35,6 +35,7 @@ def extract_filenames(content):
     if not len(lines):
         return lines
 
-    strace_mode = lines[0].startswith('execve("')
+    # The strace output will start with the exec call of its argument.
+    strace_mode = extract_exec_filename(lines[0]) is not None
     if not strace_mode:
         return lines

--- a/tests/data/strace-output/exodus-output.txt
+++ b/tests/data/strace-output/exodus-output.txt
@@ -1,0 +1,4242 @@
+execve("/home/sangaline/projects/exodus/.env/bin/exodus", ["exodus"], 0x7fffe39241e0 /* 113 vars */) = 0
+brk(NULL)                               = 0x5648fcbff000
+access("/etc/ld.so.preload", R_OK)      = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/tls/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/tls/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/tls/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/tls", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/root/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/root", 0x7fff95b518e0)   = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/tls/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/tls/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/tls/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/tls", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/python2.7/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python2.7", {st_mode=S_IFDIR|0755, st_size=20480, ...}) = 0
+openat(AT_FDCWD, "tls/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/tls/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/tls/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/tls/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/tls", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+openat(AT_FDCWD, "/opt/java/jre/lib/tls/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/tls/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/tls/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/tls/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/tls", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/x86_64/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib/x86_64", 0x7fff95b518e0) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+stat("/opt/java/jre/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libpthread.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=396501, ...}) = 0
+mmap(NULL, 396501, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f3594656000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/libpthread.so.0", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0]\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=145336, ...}) = 0
+mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594654000
+mmap(NULL, 2216400, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3594275000
+mprotect(0x7f359428e000, 2093056, PROT_NONE) = 0
+mmap(0x7f359448d000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x18000) = 0x7f359448d000
+mmap(0x7f359448f000, 12752, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f359448f000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/libc.so.6", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\3\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0`\20\2\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=2065784, ...}) = 0
+mmap(NULL, 3893488, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3593ebe000
+mprotect(0x7f359406c000, 2093056, PROT_NONE) = 0
+mmap(0x7f359426b000, 24576, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x1ad000) = 0x7f359426b000
+mmap(0x7f3594271000, 14576, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f3594271000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/libpython3.6m.so.1.0", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\320\301\5\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=3326808, ...}) = 0
+mmap(NULL, 5622392, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3593961000
+mprotect(0x7f3593c25000, 2093056, PROT_NONE) = 0
+mmap(0x7f3593e24000, 430080, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x2c3000) = 0x7f3593e24000
+mmap(0x7f3593e8d000, 199288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f3593e8d000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libdl.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/libdl.so.2", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@\r\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=14160, ...}) = 0
+mmap(NULL, 2109584, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f359375d000
+mprotect(0x7f3593760000, 2093056, PROT_NONE) = 0
+mmap(0x7f359395f000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x2000) = 0x7f359395f000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libutil.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/libutil.so.1", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\200\f\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=10064, ...}) = 0
+mmap(NULL, 2105360, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f359355a000
+mprotect(0x7f359355c000, 2093056, PROT_NONE) = 0
+mmap(0x7f359375b000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x1000) = 0x7f359375b000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libm.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/usr/lib/libm.so.6", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\3\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@v\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=1358184, ...}) = 0
+mmap(NULL, 3453480, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f359320e000
+mprotect(0x7f3593359000, 2093056, PROT_NONE) = 0
+mmap(0x7f3593558000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x14a000) = 0x7f3593558000
+close(4)                                = 0
+mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594652000
+arch_prctl(ARCH_SET_FS, 0x7f3594653540) = 0
+mprotect(0x7f359426b000, 16384, PROT_READ) = 0
+mprotect(0x7f3593558000, 4096, PROT_READ) = 0
+mprotect(0x7f359375b000, 4096, PROT_READ) = 0
+mprotect(0x7f359395f000, 4096, PROT_READ) = 0
+mprotect(0x7f359448d000, 4096, PROT_READ) = 0
+mprotect(0x7f3593e24000, 24576, PROT_READ) = 0
+mprotect(0x5648fb99d000, 4096, PROT_READ) = 0
+mprotect(0x7f35946b7000, 4096, PROT_READ) = 0
+munmap(0x7f3594656000, 396501)          = 0
+set_tid_address(0x7f3594653810)         = 12310
+set_robust_list(0x7f3594653820, 24)     = 0
+rt_sigaction(SIGRTMIN, {sa_handler=0x7f359427a770, sa_mask=[], sa_flags=SA_RESTORER|SA_SIGINFO, sa_restorer=0x7f3594286dd0}, NULL, 8) = 0
+rt_sigaction(SIGRT_1, {sa_handler=0x7f359427a810, sa_mask=[], sa_flags=SA_RESTORER|SA_RESTART|SA_SIGINFO, sa_restorer=0x7f3594286dd0}, NULL, 8) = 0
+rt_sigprocmask(SIG_UNBLOCK, [RTMIN RT_1], NULL, 8) = 0
+prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
+brk(NULL)                               = 0x5648fcbff000
+brk(0x5648fcc20000)                     = 0x5648fcc20000
+open("/usr/lib/locale/locale-archive", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1682192, ...}) = 0
+mmap(NULL, 1682192, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f3593073000
+close(4)                                = 0
+open("/usr/lib/gconv/gconv-modules.cache", O_RDONLY) = -1 ENOENT (No such file or directory)
+open("/usr/lib/gconv/gconv-modules", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=56095, ...}) = 0
+read(4, "# GNU libc iconv configuration.\n"..., 4096) = 4096
+read(4, "1002//\tJUS_I.B1.002//\nmodule\tJUS"..., 4096) = 4096
+read(4, "ISO-IR-110//\t\tISO-8859-4//\nalias"..., 4096) = 4096
+read(4, "\t\tISO-8859-14//\nalias\tISO_8859-1"..., 4096) = 4096
+read(4, "IC-ES//\nalias\tEBCDICES//\t\tEBCDIC"..., 4096) = 4096
+read(4, "DIC-CP-ES//\t\tIBM284//\nalias\tCSIB"..., 4096) = 4096
+read(4, "//\nalias\tCSIBM864//\t\tIBM864//\nal"..., 4096) = 4096
+read(4, "BM939//\nmodule\tIBM939//\t\tINTERNA"..., 4096) = 4096
+read(4, "EUC-CN//\nalias\tCN-GB//\t\t\tEUC-CN/"..., 4096) = 4096
+read(4, "T//\nmodule\tISO-2022-CN-EXT//\tINT"..., 4096) = 4096
+read(4, "//\t\tISO_5428//\nalias\tISO_5428:19"..., 4096) = 4096
+read(4, "CII-8\t1\n\n#\tfrom\t\t\tto\t\t\tmodule\t\tc"..., 4096) = 4096
+read(4, "\tfrom\t\t\tto\t\t\tmodule\t\tcost\nalias\t"..., 4096) = 4096
+brk(0x5648fcc41000)                     = 0x5648fcc41000
+read(4, "712//\t\tINTERNAL\t\tIBM12712\t\t1\nmod"..., 4096) = 2847
+read(4, "", 4096)                       = 0
+close(4)                                = 0
+futex(0x7f3594270868, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+getrandom("\x69\x0c\x06\x83\x37\x36\x2a\x04\x5f\x0f\x96\xe5\x01\x4b\xc2\x95\xc2\x2e\x16\xc8\xf9\x2a\x93\x4e", 24, GRND_NONBLOCK) = 24
+ioctl(0, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594677000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594612000
+munmap(0x7f3594612000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594612000
+fstat(0, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 3), ...}) = 0
+readlink("/home/sangaline/projects/exodus/.env/bin/python3", 0x7fff95b3eed0, 4096) = -1 EINVAL (Invalid argument)
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/bin/pyvenv.cfg", O_RDONLY) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/pyvenv.cfg", O_RDONLY) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/bin/Modules/Setup", 0x7fff95b47fa0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/bin/lib/python3.6/os.py", 0x7fff95b3fe70) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/bin/lib/python3.6/os.pyc", 0x7fff95b3fe70) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/os.py", {st_mode=S_IFREG|0644, st_size=37525, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/bin/pybuilddir.txt", 0x7fff95b47fa0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/bin/lib/python3.6/lib-dynload", 0x7fff95b47fa0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+brk(0x5648fcc66000)                     = 0x5648fcc66000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f35945d2000
+sysinfo({uptime=698693, loads=[314464, 329024, 367168], totalram=8177516544, freeram=996859904, sharedram=468746240, bufferram=48902144, totalswap=6393159680, freeswap=2591739904, procs=1080, totalhigh=0, freehigh=0, mem_unit=1}) = 0
+brk(0x5648fcc88000)                     = 0x5648fcc88000
+sigaltstack({ss_sp=0x5648fcc406f0, ss_flags=0, ss_size=8192}, {ss_sp=NULL, ss_flags=SS_DISABLE, ss_size=0}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getdents(4, /* 68 entries */, 32768)    = 2744
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594592000
+stat("/usr/lib/root", 0x7fff95b50ac0)   = -1 ENOENT (No such file or directory)
+stat("/usr/lib", {st_mode=S_IFDIR|0755, st_size=270336, ...}) = 0
+stat("/usr/lib/root", 0x7fff95b502f0)   = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/tests/data/strace-output", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 3 entries */, 32768)     = 88
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+open("/home/sangaline/", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+getdents(4, /* 589 entries */, 32768)   = 20008
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python36.zip", 0x7fff95b50ac0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python36.zip", 0x7fff95b502f0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 57 entries */, 32768)    = 1928
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b50650) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__init__.abi3.so", 0x7fff95b50650) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__init__.so", 0x7fff95b50650) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__init__.py", {st_mode=S_IFREG|0644, st_size=5642, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__init__.py", {st_mode=S_IFREG|0644, st_size=5642, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fcntl(4, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
+fstat(4, {st_mode=S_IFREG|0644, st_size=3920, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3920, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\n\26\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0@\0\0"..., 3921) = 3920
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/codecs.py", {st_mode=S_IFREG|0644, st_size=36276, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/codecs.py", {st_mode=S_IFREG|0644, st_size=36276, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/codecs.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=33932, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=33932, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\264\215\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0:\0\0\0@\0\0"..., 33933) = 33932
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 128 entries */, 32768)   = 4336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/aliases.py", {st_mode=S_IFREG|0644, st_size=15577, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/aliases.py", {st_mode=S_IFREG|0644, st_size=15577, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__pycache__/aliases.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=6264, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=6264, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\331<\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0D\1\0\0@\0\0"..., 6265) = 6264
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/utf_8.py", {st_mode=S_IFREG|0644, st_size=1005, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/utf_8.py", {st_mode=S_IFREG|0644, st_size=1005, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__pycache__/utf_8.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1582, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1582, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\355\3\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 1583) = 1582
+read(4, "", 1)                          = 0
+close(4)                                = 0
+rt_sigaction(SIGPIPE, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGXFSZ, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+getpid()                                = 12310
+rt_sigaction(SIGHUP, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGINT, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGQUIT, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGILL, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGTRAP, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGABRT, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGBUS, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGFPE, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGKILL, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGUSR1, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGSEGV, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGUSR2, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGPIPE, NULL, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, 8) = 0
+rt_sigaction(SIGALRM, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGTERM, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGSTKFLT, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGCHLD, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGCONT, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGSTOP, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGTSTP, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGTTIN, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGTTOU, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGURG, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGXCPU, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGXFSZ, NULL, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, 8) = 0
+rt_sigaction(SIGVTALRM, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGPROF, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGWINCH, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGIO, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGPWR, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGSYS, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_2, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_3, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_4, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_5, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_6, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_7, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_8, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_9, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_10, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_11, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_12, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_13, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_14, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_15, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_16, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_17, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_18, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_19, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_20, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_21, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_22, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_23, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_24, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_25, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_26, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_27, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_28, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_29, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_30, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_31, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGRT_32, NULL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+rt_sigaction(SIGINT, {sa_handler=0x7f3593b3b400, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/latin_1.py", {st_mode=S_IFREG|0644, st_size=1264, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/latin_1.py", {st_mode=S_IFREG|0644, st_size=1264, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/encodings/__pycache__/latin_1.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1864, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1864, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\360\4\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0@\0\0"..., 1865) = 1864
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/io.py", {st_mode=S_IFREG|0644, st_size=3517, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/io.py", {st_mode=S_IFREG|0644, st_size=3517, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/io.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3419, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3419, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\275\r\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\22\0\0\0@\0\0"..., 3420) = 3419
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/abc.py", {st_mode=S_IFREG|0644, st_size=8648, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/abc.py", {st_mode=S_IFREG|0644, st_size=8648, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/abc.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=7520, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=7520, ...}) = 0
+brk(0x5648fcca9000)                     = 0x5648fcca9000
+read(4, "3\r\r\n\243\344NZ\310!\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0@\0\0"..., 7521) = 7520
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcca7000)                     = 0x5648fcca7000
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/_weakrefset.py", {st_mode=S_IFREG|0644, st_size=5705, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/_weakrefset.py", {st_mode=S_IFREG|0644, st_size=5705, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/_weakrefset.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=7860, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=7860, ...}) = 0
+read(4, "3\r\r\n\243\344NZI\26\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 7861) = 7860
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3594552000
+dup(0)                                  = 4
+close(4)                                = 0
+fstat(0, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 3), ...}) = 0
+ioctl(0, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+lseek(0, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek)
+ioctl(0, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+ioctl(0, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+lseek(0, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek)
+dup(1)                                  = 4
+close(4)                                = 0
+fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 3), ...}) = 0
+ioctl(1, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+lseek(1, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek)
+ioctl(1, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+ioctl(1, TCGETS, {B38400 opost isig icanon echo ...}) = 0
+lseek(1, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek)
+dup(2)                                  = 4
+close(4)                                = 0
+fstat(2, {st_mode=S_IFREG|0644, st_size=47417, ...}) = 0
+ioctl(2, TCGETS, 0x7fff95b51ae0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(2, 0, SEEK_CUR)                   = 47570
+ioctl(2, TCGETS, 0x7fff95b51dd0)        = -1 ENOTTY (Inappropriate ioctl for device)
+ioctl(2, TCGETS, 0x7fff95b51d90)        = -1 ENOTTY (Inappropriate ioctl for device)
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/_bootlocale.py", {st_mode=S_IFREG|0644, st_size=1301, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/_bootlocale.py", {st_mode=S_IFREG|0644, st_size=1301, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/_bootlocale.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1012, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1012, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\25\5\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 1013) = 1012
+read(4, "", 1)                          = 0
+close(4)                                = 0
+lseek(2, 0, SEEK_CUR)                   = 49157
+lseek(2, 0, SEEK_CUR)                   = 49205
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site.py", {st_mode=S_IFREG|0644, st_size=27543, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site.py", {st_mode=S_IFREG|0644, st_size=27543, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/site.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=20702, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=20702, ...}) = 0
+read(4, "3\r\r\nI\204kZ\227k\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\24\0\0\0@\0\0"..., 20703) = 20702
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/os.py", {st_mode=S_IFREG|0644, st_size=37525, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/os.py", {st_mode=S_IFREG|0644, st_size=37525, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/os.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=29660, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=29660, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\225\222\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0000\0\0\0@\0\0"..., 29661) = 29660
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/stat.py", {st_mode=S_IFREG|0644, st_size=5038, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/stat.py", {st_mode=S_IFREG|0644, st_size=5038, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/stat.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3883, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3883, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\256\23\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 3884) = 3883
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/posixpath.py", {st_mode=S_IFREG|0644, st_size=15349, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/posixpath.py", {st_mode=S_IFREG|0644, st_size=15349, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/posixpath.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=10421, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=10421, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\365;\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0&\0\0\0@\0\0"..., 10422) = 10421
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 151552, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f359452d000
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/genericpath.py", {st_mode=S_IFREG|0644, st_size=4756, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/genericpath.py", {st_mode=S_IFREG|0644, st_size=4756, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/genericpath.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3758, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3758, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\224\22\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 3759) = 3758
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/_collections_abc.py", {st_mode=S_IFREG|0644, st_size=26303, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/_collections_abc.py", {st_mode=S_IFREG|0644, st_size=26303, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/_collections_abc.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=28875, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=28875, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\277f\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\31\0\0\0@\0\0"..., 28876) = 28875
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f35944ed000
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 69 entries */, 32768)    = 4304
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/orig-prefix.txt", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b50910)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+ioctl(4, TCGETS, 0x7fff95b508c0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4, ...}) = 0
+read(4, "/usr", 5)                      = 4
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib/python3.6/plat-x86_64-linux-gnu", 0x7fff95b509e0) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/lib-tk", 0x7fff95b509e0) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/python3.6/lib-tk", 0x7fff95b509e0) = -1 ENOENT (No such file or directory)
+getcwd("/home/sangaline/projects/exodus/tests/data/strace-output", 1024) = 57
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/no-global-site-packages.txt", {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/local/lib64/python3.6/site-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/lib/python3.6/site-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/lib/site-python", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/python3.6/lib-dynload", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/local/lib/python3.6/dist-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/lib/python3/dist-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/lib/dist-python", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib64/python3.6/site-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 76 entries */, 32768)    = 2952
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/easy-install.pth", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=36, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b50350)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+ioctl(4, TCGETS, 0x7fff95b50300)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+read(4, "/home/sangaline/projects/exodus/"..., 8192) = 36
+stat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+read(4, "", 8192)                       = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/site-python", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/python3.6/lib-dynload", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/local/lib/python3.6/dist-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3/dist-packages", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/dist-python", 0x7fff95b508b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+open("/home/sangaline", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+getdents(4, /* 589 entries */, 32768)   = 20008
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+brk(0x5648fccc8000)                     = 0x5648fccc8000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib64/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 208 entries */, 32768)   = 6912
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 208 entries */, 32768)   = 6912
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3593033000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 76 entries */, 32768)    = 2952
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 5 entries */, 32768)     = 176
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin/exodus", {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/bin/exodus", O_RDONLY) = 4
+ioctl(4, FIOCLEX)                       = 0
+fstat(4, {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+fstat(4, {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+lseek(4, 0, SEEK_SET)                   = 0
+read(4, "#!/home/sangaline/projects/exodu"..., 390) = 390
+read(4, "s', 'exodus')()\n    )\n", 4096) = 22
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin/exodus", {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+readlink("/home/sangaline/projects/exodus/.env/bin/exodus", 0x7fff95b41090, 4096) = -1 EINVAL (Invalid argument)
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/bin/exodus", {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/bin/exodus", O_RDONLY) = 4
+ioctl(4, FIOCLEX)                       = 0
+fstat(4, {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b52040)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0755, st_size=412, ...}) = 0
+read(4, "#!/home/sangaline/projects/exodu"..., 4096) = 412
+lseek(4, 0, SEEK_SET)                   = 0
+read(4, "#!/home/sangaline/projects/exodu"..., 4096) = 412
+read(4, "", 4096)                       = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/bin", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 46 entries */, 32768)    = 1480
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/re.py", {st_mode=S_IFREG|0644, st_size=15552, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/re.py", {st_mode=S_IFREG|0644, st_size=15552, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/re.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=14090, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=14090, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\300<\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0#\0\0\0@\0\0"..., 14091) = 14090
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/enum.py", {st_mode=S_IFREG|0644, st_size=33472, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/enum.py", {st_mode=S_IFREG|0644, st_size=33472, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/enum.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=23443, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=23443, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\300\202\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\17\0\0\0@\0\0"..., 23444) = 23443
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcceb000)                     = 0x5648fcceb000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/types.py", {st_mode=S_IFREG|0644, st_size=8870, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/types.py", {st_mode=S_IFREG|0644, st_size=8870, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/types.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=8233, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=8233, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\246\"\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 8234) = 8233
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/functools.py", {st_mode=S_IFREG|0644, st_size=31142, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/functools.py", {st_mode=S_IFREG|0644, st_size=31142, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/functools.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=23959, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=23959, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\246y\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0+\0\0\0@\0\0"..., 23960) = 23959
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4ccf0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__init__.abi3.so", 0x7fff95b4ccf0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__init__.so", 0x7fff95b4ccf0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__init__.py", {st_mode=S_IFREG|0644, st_size=45812, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__init__.py", {st_mode=S_IFREG|0644, st_size=45812, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=45804, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=45804, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\364\262\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0$\0\0\0@\0\0"..., 45805) = 45804
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ff3000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/operator.py", {st_mode=S_IFREG|0644, st_size=10863, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/operator.py", {st_mode=S_IFREG|0644, st_size=10863, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/operator.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=13945, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=13945, ...}) = 0
+read(4, "3\r\r\n\243\344NZo*\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0006\0\0\0@\0\0"..., 13946) = 13945
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/keyword.py", {st_mode=S_IFREG|0755, st_size=2211, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/keyword.py", {st_mode=S_IFREG|0755, st_size=2211, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/keyword.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1797, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1797, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\243\10\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0!\0\0\0@\0\0"..., 1798) = 1797
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/heapq.py", {st_mode=S_IFREG|0644, st_size=22929, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/heapq.py", {st_mode=S_IFREG|0644, st_size=22929, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/heapq.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=14324, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=14324, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\221Y\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0#\0\0\0@\0\0"..., 14325) = 14324
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_heapq.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=21392, ...}) = 0
+futex(0x7f3593960048, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_heapq.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0 \v\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=21392, ...}) = 0
+mmap(NULL, 2116912, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3592dee000
+mprotect(0x7f3592df1000, 2093056, PROT_NONE) = 0
+mmap(0x7f3592ff0000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x2000) = 0x7f3592ff0000
+close(4)                                = 0
+mprotect(0x7f3592ff0000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/reprlib.py", {st_mode=S_IFREG|0644, st_size=5336, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/reprlib.py", {st_mode=S_IFREG|0644, st_size=5336, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/reprlib.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=5432, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=5432, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\330\24\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 5433) = 5432
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/weakref.py", {st_mode=S_IFREG|0644, st_size=20466, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/weakref.py", {st_mode=S_IFREG|0644, st_size=20466, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/weakref.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=19175, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=19175, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\362O\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 19176) = 19175
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592dae000
+munmap(0x7f3592dae000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592dae000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/collections", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 5 entries */, 32768)     = 144
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/abc.py", {st_mode=S_IFREG|0644, st_size=68, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/collections/abc.py", {st_mode=S_IFREG|0644, st_size=68, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/collections/__pycache__/abc.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=171, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=171, ...}) = 0
+read(4, "3\r\r\n\244\344NZD\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\2\0\0\0@\0\0"..., 172) = 171
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/sre_compile.py", {st_mode=S_IFREG|0644, st_size=19338, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/sre_compile.py", {st_mode=S_IFREG|0644, st_size=19338, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/sre_compile.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=10310, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=10310, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\212K\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\21\0\0\0@\0\0"..., 10311) = 10310
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/sre_parse.py", {st_mode=S_IFREG|0644, st_size=36536, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/sre_parse.py", {st_mode=S_IFREG|0644, st_size=36536, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/sre_parse.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=20390, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=20390, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\270\216\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 20391) = 20390
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcd10000)                     = 0x5648fcd10000
+brk(0x5648fcd06000)                     = 0x5648fcd06000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/sre_constants.py", {st_mode=S_IFREG|0644, st_size=6821, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/sre_constants.py", {st_mode=S_IFREG|0644, st_size=6821, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/sre_constants.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=6004, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=6004, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\245\32\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\20\0\0\0@\0\0"..., 6005) = 6004
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/copyreg.py", {st_mode=S_IFREG|0644, st_size=7007, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/copyreg.py", {st_mode=S_IFREG|0644, st_size=7007, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/copyreg.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4276, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4276, ...}) = 0
+read(4, "3\r\r\n\243\344NZ_\33\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\f\0\0\0@\0\0"..., 4277) = 4276
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b506b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__init__.abi3.so", 0x7fff95b506b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__init__.so", 0x7fff95b506b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__init__.py", {st_mode=S_IFREG|0644, st_size=106094, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__init__.py", {st_mode=S_IFREG|0644, st_size=106094, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=97751, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=97751, ...}) = 0
+read(4, "3\r\r\nK\204kZn\236\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0^\0\0\0@\0\0"..., 97752) = 97751
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcd3d000)                     = 0x5648fcd3d000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592d6e000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/__future__.py", {st_mode=S_IFREG|0644, st_size=4841, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/__future__.py", {st_mode=S_IFREG|0644, st_size=4841, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/__future__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4199, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4199, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\351\22\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\t\0\0\0@\0\0"..., 4200) = 4199
+read(4, "", 1)                          = 0
+close(4)                                = 0
+open("/etc/localtime", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3545, ...}) = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3545, ...}) = 0
+read(4, "TZif2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0\5\0\0\0\0"..., 4096) = 3545
+lseek(4, -2261, SEEK_CUR)               = 1284
+read(4, "TZif2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0\5\0\0\0\0"..., 4096) = 2261
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/zipfile.py", {st_mode=S_IFREG|0644, st_size=75634, ...}) = 0
+stat("/usr/lib64/python3.6/zipfile.py", {st_mode=S_IFREG|0644, st_size=75634, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/zipfile.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=48204, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=48204, ...}) = 0
+read(4, "3\r\r\n\243\344NZr'\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0002\0\0\0@\0\0"..., 48205) = 48204
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4e110) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__init__.abi3.so", 0x7fff95b4e110) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__init__.so", 0x7fff95b4e110) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__init__.py", {st_mode=S_IFREG|0644, st_size=5870, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__init__.py", {st_mode=S_IFREG|0644, st_size=5870, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3590, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3590, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\356\26\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0#\0\0\0@\0\0"..., 3591) = 3590
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/warnings.py", {st_mode=S_IFREG|0644, st_size=18488, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/warnings.py", {st_mode=S_IFREG|0644, st_size=18488, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/warnings.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=13290, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=13290, ...}) = 0
+read(4, "3\r\r\n\243\344NZ8H\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 13291) = 13290
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592d2e000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/util.py", {st_mode=S_IFREG|0644, st_size=10883, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/util.py", {st_mode=S_IFREG|0644, st_size=10883, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__pycache__/util.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=8890, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=8890, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\203*\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 8891) = 8890
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/abc.py", {st_mode=S_IFREG|0644, st_size=10782, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/abc.py", {st_mode=S_IFREG|0644, st_size=10782, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__pycache__/abc.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11283, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11283, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\36*\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\"\0\0\0@\0\0"..., 11284) = 11283
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/machinery.py", {st_mode=S_IFREG|0644, st_size=844, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/machinery.py", {st_mode=S_IFREG|0644, st_size=844, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/importlib/__pycache__/machinery.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=940, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=940, ...}) = 0
+read(4, "3\r\r\n\244\344NZL\3\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\2\0\0\0@\0\0"..., 941) = 940
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/contextlib.py", {st_mode=S_IFREG|0644, st_size=13162, ...}) = 0
+stat("/usr/lib64/python3.6/contextlib.py", {st_mode=S_IFREG|0644, st_size=13162, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/contextlib.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11158, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11158, ...}) = 0
+read(4, "3\r\r\n\243\344NZj3\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\10\0\0\0@\0\0"..., 11159) = 11158
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/shutil.py", {st_mode=S_IFREG|0644, st_size=40227, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/shutil.py", {st_mode=S_IFREG|0644, st_size=40227, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/shutil.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=30417, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=30417, ...}) = 0
+read(4, "3\r\r\n\243\344NZ#\235\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0A\0\0\0@\0\0"..., 30418) = 30417
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/fnmatch.py", {st_mode=S_IFREG|0644, st_size=3166, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/fnmatch.py", {st_mode=S_IFREG|0644, st_size=3166, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/fnmatch.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2906, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2906, ...}) = 0
+read(4, "3\r\r\n\243\344NZ^\f\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 2907) = 2906
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/zlib.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=36760, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/zlib.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0`\31\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=36760, ...}) = 0
+mmap(NULL, 2132208, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3592b25000
+mprotect(0x7f3592b2c000, 2093056, PROT_NONE) = 0
+mmap(0x7f3592d2b000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x6000) = 0x7f3592d2b000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libz.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=396501, ...}) = 0
+mmap(NULL, 396501, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f3592ac4000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/libz.so.1", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\360!\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=92056, ...}) = 0
+mmap(NULL, 2187280, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f35928ad000
+mprotect(0x7f35928c3000, 2093056, PROT_NONE) = 0
+mmap(0x7f3592ac2000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x15000) = 0x7f3592ac2000
+close(4)                                = 0
+mprotect(0x7f3592ac2000, 4096, PROT_READ) = 0
+mprotect(0x7f3592d2b000, 4096, PROT_READ) = 0
+munmap(0x7f3592ac4000, 396501)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/bz2.py", {st_mode=S_IFREG|0644, st_size=12478, ...}) = 0
+stat("/usr/lib64/python3.6/bz2.py", {st_mode=S_IFREG|0644, st_size=12478, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/bz2.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11282, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11282, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\2760\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 11283) = 11282
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/_compression.py", {st_mode=S_IFREG|0644, st_size=5340, ...}) = 0
+stat("/usr/lib64/python3.6/_compression.py", {st_mode=S_IFREG|0644, st_size=5340, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/_compression.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4104, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4104, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\334\24\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 4105) = 4104
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+munmap(0x7f3592ae5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592ae5000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/threading.py", {st_mode=S_IFREG|0644, st_size=49036, ...}) = 0
+stat("/usr/lib64/python3.6/threading.py", {st_mode=S_IFREG|0644, st_size=49036, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/threading.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=37241, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=37241, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\214\277\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\35\0\0\0@\0\0"..., 37242) = 37241
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/traceback.py", {st_mode=S_IFREG|0644, st_size=23116, ...}) = 0
+stat("/usr/lib64/python3.6/traceback.py", {st_mode=S_IFREG|0644, st_size=23116, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/traceback.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=19536, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=19536, ...}) = 0
+read(4, "3\r\r\n\243\344NZLZ\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\23\0\0\0@\0\0"..., 19537) = 19536
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/linecache.py", {st_mode=S_IFREG|0644, st_size=5312, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/linecache.py", {st_mode=S_IFREG|0644, st_size=5312, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/linecache.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3810, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3810, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\300\24\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 3811) = 3810
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/tokenize.py", {st_mode=S_IFREG|0644, st_size=28959, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/tokenize.py", {st_mode=S_IFREG|0644, st_size=28959, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/tokenize.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=18575, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=18575, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\37q\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0-\0\0\0@\0\0"..., 18576) = 18575
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/token.py", {st_mode=S_IFREG|0644, st_size=3075, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/token.py", {st_mode=S_IFREG|0644, st_size=3075, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/token.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3352, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3352, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\3\f\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 3353) = 3352
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f359286d000
+munmap(0x7f359286d000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f359286d000
+munmap(0x7f359286d000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f359286d000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_bz2.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=21416, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_bz2.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\340\23\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=21416, ...}) = 0
+mmap(NULL, 2116856, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3592668000
+mprotect(0x7f359266c000, 2093056, PROT_NONE) = 0
+mmap(0x7f359286b000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x3000) = 0x7f359286b000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=396501, ...}) = 0
+mmap(NULL, 396501, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f3592607000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/libbz2.so.1.0", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@\24\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=67632, ...}) = 0
+mmap(NULL, 2161736, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f35923f7000
+mprotect(0x7f3592406000, 2093056, PROT_NONE) = 0
+mmap(0x7f3592605000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0xe000) = 0x7f3592605000
+close(4)                                = 0
+mprotect(0x7f3592605000, 4096, PROT_READ) = 0
+mprotect(0x7f359286b000, 4096, PROT_READ) = 0
+munmap(0x7f3592607000, 396501)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/lzma.py", {st_mode=S_IFREG|0644, st_size=12983, ...}) = 0
+stat("/usr/lib64/python3.6/lzma.py", {st_mode=S_IFREG|0644, st_size=12983, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/lzma.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11992, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11992, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\2672\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0$\0\0\0@\0\0"..., 11993) = 11992
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_lzma.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=36872, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_lzma.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0 \37\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=36872, ...}) = 0
+mmap(NULL, 2132328, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f35921ee000
+mprotect(0x7f35921f5000, 2093056, PROT_NONE) = 0
+mmap(0x7f35923f4000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x6000) = 0x7f35923f4000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/liblzma.so.5", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=396501, ...}) = 0
+mmap(NULL, 396501, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f3592607000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/liblzma.so.5", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0002\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=154344, ...}) = 0
+mmap(NULL, 2249360, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3591fc8000
+mprotect(0x7f3591fed000, 2093056, PROT_NONE) = 0
+mmap(0x7f35921ec000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x24000) = 0x7f35921ec000
+close(4)                                = 0
+mprotect(0x7f35921ec000, 4096, PROT_READ) = 0
+mprotect(0x7f35923f4000, 4096, PROT_READ) = 0
+munmap(0x7f3592607000, 396501)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/grp.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=11768, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/grp.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0p\17\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=11768, ...}) = 0
+mmap(NULL, 2107664, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3591dc5000
+mprotect(0x7f3591dc7000, 2093056, PROT_NONE) = 0
+mmap(0x7f3591fc6000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x1000) = 0x7f3591fc6000
+close(4)                                = 0
+mprotect(0x7f3591fc6000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/struct.py", {st_mode=S_IFREG|0644, st_size=257, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/struct.py", {st_mode=S_IFREG|0644, st_size=257, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/struct.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=344, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=344, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\1\1\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\10\0\0\0@\0\0"..., 345) = 344
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_struct.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=54184, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_struct.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0000(\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=54184, ...}) = 0
+mmap(NULL, 2149640, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3591bb8000
+mprotect(0x7f3591bc2000, 2097152, PROT_NONE) = 0
+mmap(0x7f3591dc2000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0xa000) = 0x7f3591dc2000
+close(4)                                = 0
+mprotect(0x7f3591dc2000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/binascii.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=29144, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/binascii.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\20\24\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=29144, ...}) = 0
+mmap(NULL, 2124600, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f35919b1000
+mprotect(0x7f35919b7000, 2093056, PROT_NONE) = 0
+mmap(0x7f3591bb6000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x5000) = 0x7f3591bb6000
+close(4)                                = 0
+mprotect(0x7f3591bb6000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/pkgutil.py", {st_mode=S_IFREG|0644, st_size=21315, ...}) = 0
+stat("/usr/lib64/python3.6/pkgutil.py", {st_mode=S_IFREG|0644, st_size=21315, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/pkgutil.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=16261, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=16261, ...}) = 0
+read(4, "3\r\r\n\243\344NZCS\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\f\0\0\0@\0\0"..., 16262) = 16261
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcd5e000)                     = 0x5648fcd5e000
+brk(0x5648fcd5d000)                     = 0x5648fcd5d000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/platform.py", {st_mode=S_IFREG|0755, st_size=46115, ...}) = 0
+stat("/usr/lib64/python3.6/platform.py", {st_mode=S_IFREG|0755, st_size=46115, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/platform.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=27984, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=27984, ...}) = 0
+read(4, "3\r\r\n\243\344NZ#\264\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\36\0\0\0@\0\0"..., 27985) = 27984
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 299008, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f359261f000
+munmap(0x7f359452d000, 151552)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/subprocess.py", {st_mode=S_IFREG|0644, st_size=61799, ...}) = 0
+stat("/usr/lib64/python3.6/subprocess.py", {st_mode=S_IFREG|0644, st_size=61799, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/subprocess.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=35156, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=35156, ...}) = 0
+read(4, "3\r\r\n\243\344NZg\361\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\26\0\0\0@\0\0"..., 35157) = 35156
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/signal.py", {st_mode=S_IFREG|0644, st_size=2123, ...}) = 0
+stat("/usr/lib64/python3.6/signal.py", {st_mode=S_IFREG|0644, st_size=2123, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/signal.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2515, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2515, ...}) = 0
+read(4, "3\r\r\n\243\344NZK\10\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0@\0\0"..., 2516) = 2515
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3591971000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_posixsubprocess.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=15088, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_posixsubprocess.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\200\21\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=15088, ...}) = 0
+mmap(NULL, 2110608, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f359176d000
+mprotect(0x7f3591770000, 2093056, PROT_NONE) = 0
+mmap(0x7f359196f000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x2000) = 0x7f359196f000
+close(4)                                = 0
+mprotect(0x7f359196f000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/select.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=35640, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/select.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0\34\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=35640, ...}) = 0
+mmap(NULL, 2131160, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3591564000
+mprotect(0x7f359156a000, 2097152, PROT_NONE) = 0
+mmap(0x7f359176a000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x6000) = 0x7f359176a000
+close(4)                                = 0
+mprotect(0x7f359176a000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/selectors.py", {st_mode=S_IFREG|0644, st_size=19438, ...}) = 0
+stat("/usr/lib64/python3.6/selectors.py", {st_mode=S_IFREG|0644, st_size=19438, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/selectors.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=17697, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=17697, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\356K\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 17698) = 17697
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/math.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=48880, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/math.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\340%\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=48880, ...}) = 0
+mmap(NULL, 2144400, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3591358000
+mprotect(0x7f3591362000, 2093056, PROT_NONE) = 0
+mmap(0x7f3591561000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x9000) = 0x7f3591561000
+close(4)                                = 0
+mprotect(0x7f3591561000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/plistlib.py", {st_mode=S_IFREG|0644, st_size=31980, ...}) = 0
+stat("/usr/lib64/python3.6/plistlib.py", {st_mode=S_IFREG|0644, st_size=31980, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/plistlib.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=27618, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=27618, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\354|\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\16\0\0\0@\0\0"..., 27619) = 27618
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/datetime.py", {st_mode=S_IFREG|0644, st_size=80145, ...}) = 0
+stat("/usr/lib64/python3.6/datetime.py", {st_mode=S_IFREG|0644, st_size=80145, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/datetime.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=53750, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=53750, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\0219\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 53751) = 53750
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcd88000)                     = 0x5648fcd88000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3591318000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_datetime.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=111752, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_datetime.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\360?\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=111752, ...}) = 0
+mmap(NULL, 2207352, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f35910fd000
+mprotect(0x7f3591115000, 2097152, PROT_NONE) = 0
+mmap(0x7f3591315000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x18000) = 0x7f3591315000
+close(4)                                = 0
+mprotect(0x7f3591315000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/xml/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4d850) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/xml/__init__.abi3.so", 0x7fff95b4d850) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/xml/__init__.so", 0x7fff95b4d850) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/xml/__init__.py", {st_mode=S_IFREG|0644, st_size=557, ...}) = 0
+stat("/usr/lib64/python3.6/xml/__init__.py", {st_mode=S_IFREG|0644, st_size=557, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/xml/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=680, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=680, ...}) = 0
+read(4, "3\r\r\n\244\344NZ-\2\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 681) = 680
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/xml", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/xml", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/xml", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib64/python3.6/xml", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 8 entries */, 32768)     = 224
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/xml/parsers/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4e110) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/xml/parsers/__init__.abi3.so", 0x7fff95b4e110) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/xml/parsers/__init__.so", 0x7fff95b4e110) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/xml/parsers/__init__.py", {st_mode=S_IFREG|0644, st_size=167, ...}) = 0
+stat("/usr/lib64/python3.6/xml/parsers/__init__.py", {st_mode=S_IFREG|0644, st_size=167, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/xml/parsers/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=285, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=285, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\247\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\1\0\0\0@\0\0"..., 286) = 285
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/xml/parsers", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/xml/parsers", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/xml/parsers", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib64/python3.6/xml/parsers", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 5 entries */, 32768)     = 144
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/xml/parsers/expat.py", {st_mode=S_IFREG|0644, st_size=248, ...}) = 0
+stat("/usr/lib64/python3.6/xml/parsers/expat.py", {st_mode=S_IFREG|0644, st_size=248, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/xml/parsers/__pycache__/expat.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=314, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=314, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\370\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 315) = 314
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/pyexpat.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=68664, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/pyexpat.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\20/\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=68664, ...}) = 0
+mmap(NULL, 2164576, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3590eec000
+mprotect(0x7f3590efb000, 2093056, PROT_NONE) = 0
+mmap(0x7f35910fa000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0xe000) = 0x7f35910fa000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libexpat.so.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=396501, ...}) = 0
+mmap(NULL, 396501, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f3590e8b000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/libexpat.so.1", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0 :\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=202416, ...}) = 0
+mmap(NULL, 2297872, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3590c59000
+mprotect(0x7f3590c88000, 2097152, PROT_NONE) = 0
+mmap(0x7f3590e88000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x2f000) = 0x7f3590e88000
+close(4)                                = 0
+mprotect(0x7f3590e88000, 8192, PROT_READ) = 0
+mprotect(0x7f35910fa000, 4096, PROT_READ) = 0
+munmap(0x7f3590e8b000, 396501)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4ef80) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/email/__init__.abi3.so", 0x7fff95b4ef80) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/email/__init__.so", 0x7fff95b4ef80) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/email/__init__.py", {st_mode=S_IFREG|0644, st_size=1766, ...}) = 0
+stat("/usr/lib64/python3.6/email/__init__.py", {st_mode=S_IFREG|0644, st_size=1766, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1663, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1663, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\346\6\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\21\0\0\0@\0\0"..., 1664) = 1663
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib64/python3.6/email", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 25 entries */, 32768)    = 864
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email/parser.py", {st_mode=S_IFREG|0644, st_size=5043, ...}) = 0
+stat("/usr/lib64/python3.6/email/parser.py", {st_mode=S_IFREG|0644, st_size=5043, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/parser.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=5719, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=5719, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\263\23\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 5720) = 5719
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/feedparser.py", {st_mode=S_IFREG|0644, st_size=22775, ...}) = 0
+stat("/usr/lib64/python3.6/email/feedparser.py", {st_mode=S_IFREG|0644, st_size=22775, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/feedparser.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=10638, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=10638, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\367X\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 10639) = 10638
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/errors.py", {st_mode=S_IFREG|0644, st_size=3535, ...}) = 0
+stat("/usr/lib64/python3.6/email/errors.py", {st_mode=S_IFREG|0644, st_size=3535, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/errors.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=5951, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=5951, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\317\r\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0@\0\0"..., 5952) = 5951
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/_policybase.py", {st_mode=S_IFREG|0644, st_size=15073, ...}) = 0
+stat("/usr/lib64/python3.6/email/_policybase.py", {st_mode=S_IFREG|0644, st_size=15073, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/_policybase.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=14822, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=14822, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\341:\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 14823) = 14822
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/header.py", {st_mode=S_IFREG|0644, st_size=24102, ...}) = 0
+stat("/usr/lib64/python3.6/email/header.py", {st_mode=S_IFREG|0644, st_size=24102, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/header.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=16474, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=16474, ...}) = 0
+read(4, "3\r\r\n\244\344NZ&^\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 16475) = 16474
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/quoprimime.py", {st_mode=S_IFREG|0644, st_size=9859, ...}) = 0
+stat("/usr/lib64/python3.6/email/quoprimime.py", {st_mode=S_IFREG|0644, st_size=9859, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/quoprimime.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=7674, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=7674, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\203&\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\n\0\0\0@\0\0"..., 7675) = 7674
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/string.py", {st_mode=S_IFREG|0644, st_size=11795, ...}) = 0
+stat("/usr/lib64/python3.6/string.py", {st_mode=S_IFREG|0644, st_size=11795, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/string.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=7964, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=7964, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\23.\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\f\0\0\0@\0\0"..., 7965) = 7964
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/base64mime.py", {st_mode=S_IFREG|0644, st_size=3558, ...}) = 0
+stat("/usr/lib64/python3.6/email/base64mime.py", {st_mode=S_IFREG|0644, st_size=3558, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/base64mime.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3212, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3212, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\346\r\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 3213) = 3212
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/base64.py", {st_mode=S_IFREG|0755, st_size=20487, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/base64.py", {st_mode=S_IFREG|0755, st_size=20487, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/base64.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=17167, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=17167, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\7P\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\22\0\0\0@\0\0"..., 17168) = 17167
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/charset.py", {st_mode=S_IFREG|0644, st_size=17151, ...}) = 0
+stat("/usr/lib64/python3.6/email/charset.py", {st_mode=S_IFREG|0644, st_size=17151, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/charset.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11505, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11505, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\377B\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\31\0\0\0@\0\0"..., 11506) = 11505
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/encoders.py", {st_mode=S_IFREG|0644, st_size=1786, ...}) = 0
+stat("/usr/lib64/python3.6/email/encoders.py", {st_mode=S_IFREG|0644, st_size=1786, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/encoders.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1634, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1634, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\372\6\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 1635) = 1634
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/quopri.py", {st_mode=S_IFREG|0755, st_size=7254, ...}) = 0
+stat("/usr/lib64/python3.6/quopri.py", {st_mode=S_IFREG|0755, st_size=7254, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/quopri.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=5773, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=5773, ...}) = 0
+read(4, "3\r\r\n\243\344NZV\34\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 5774) = 5773
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3590eac000
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/utils.py", {st_mode=S_IFREG|0644, st_size=13897, ...}) = 0
+stat("/usr/lib64/python3.6/email/utils.py", {st_mode=S_IFREG|0644, st_size=13897, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/utils.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=9868, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=9868, ...}) = 0
+read(4, "3\r\r\n\244\344NZI6\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\17\0\0\0@\0\0"..., 9869) = 9868
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/random.py", {st_mode=S_IFREG|0644, st_size=27310, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/random.py", {st_mode=S_IFREG|0644, st_size=27310, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/random.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=19274, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=19274, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\256j\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\30\0\0\0@\0\0"..., 19275) = 19274
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/hashlib.py", {st_mode=S_IFREG|0644, st_size=9477, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/hashlib.py", {st_mode=S_IFREG|0644, st_size=9477, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/hashlib.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=6668, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=6668, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\5%\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0$\0\0\0@\0\0"..., 6669) = 6668
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_hashlib.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=29000, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_hashlib.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\20\33\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=29000, ...}) = 0
+mmap(NULL, 2124536, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3590a52000
+mprotect(0x7f3590a58000, 2093056, PROT_NONE) = 0
+mmap(0x7f3590c57000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x5000) = 0x7f3590c57000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/python2.7/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "tls/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/lib/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/opt/java/jre/lib/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/tls/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/x86_64/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "./lib/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=396501, ...}) = 0
+mmap(NULL, 396501, PROT_READ, MAP_PRIVATE, 4, 0) = 0x7f35909f1000
+close(4)                                = 0
+openat(AT_FDCWD, "/usr/lib/libcrypto.so.1.1", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0p\6\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=2594952, ...}) = 0
+mmap(NULL, 4704640, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3590574000
+mprotect(0x7f35907c7000, 2093056, PROT_NONE) = 0
+mmap(0x7f35909c6000, 163840, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x252000) = 0x7f35909c6000
+mmap(0x7f35909ee000, 10624, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f35909ee000
+close(4)                                = 0
+mprotect(0x7f35909c6000, 122880, PROT_READ) = 0
+mprotect(0x7f3590c57000, 4096, PROT_READ) = 0
+munmap(0x7f35909f1000, 396501)          = 0
+futex(0x7f35909eee58, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+futex(0x7f35909eef40, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+futex(0x7f35909eee3c, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+futex(0x7f35909eee34, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+futex(0x7f35909eec90, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+futex(0x7f35909eee4c, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_blake2.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=62160, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_blake2.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0000\32\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=62160, ...}) = 0
+brk(0x5648fcda9000)                     = 0x5648fcda9000
+mmap(NULL, 2157664, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f3590365000
+mprotect(0x7f3590373000, 2093056, PROT_NONE) = 0
+mmap(0x7f3590572000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0xd000) = 0x7f3590572000
+close(4)                                = 0
+mprotect(0x7f3590572000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_sha3.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=96488, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_sha3.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\320\36\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=96488, ...}) = 0
+mmap(NULL, 2191928, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f359014d000
+mprotect(0x7f3590163000, 2093056, PROT_NONE) = 0
+mmap(0x7f3590362000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x15000) = 0x7f3590362000
+close(4)                                = 0
+mprotect(0x7f3590362000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/bisect.py", {st_mode=S_IFREG|0644, st_size=2595, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/bisect.py", {st_mode=S_IFREG|0644, st_size=2595, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/bisect.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2708, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2708, ...}) = 0
+read(4, "3\r\r\n\243\344NZ#\n\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 2709) = 2708
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_bisect.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=12176, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_bisect.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@\f\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=12176, ...}) = 0
+mmap(NULL, 2107696, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f358ff4a000
+mprotect(0x7f358ff4c000, 2093056, PROT_NONE) = 0
+mmap(0x7f359014b000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x1000) = 0x7f359014b000
+close(4)                                = 0
+mprotect(0x7f359014b000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_random.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=18936, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_random.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@\20\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=18936, ...}) = 0
+mmap(NULL, 2114456, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f358fd45000
+mprotect(0x7f358fd49000, 2093056, PROT_NONE) = 0
+mmap(0x7f358ff48000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x3000) = 0x7f358ff48000
+close(4)                                = 0
+mprotect(0x7f358ff48000, 4096, PROT_READ) = 0
+getrandom("\x21\x1a\x1b\xa0\xd8\xea\x40\x12\x0a\x0b\x9e\xa6\x44\xb4\xb5\xd2\x75\x7e\xe0\x78\xd2\xa1\x8a\x64\xef\x38\x95\x42\x70\xc1\x6f\x6d"..., 2496, GRND_NONBLOCK) = 2496
+getrandom("\x27\xb3\x4d\x40\x0c\xdf\xa3\xb3\xf3\x7d\x83\xa1\xd0\x1c\xa6\xed\x63\xf3\x4e\xd9\x5a\xbf\xb2\x80\x18\xb1\x3c\x01\xf1\x02\xc9\xc8"..., 2496, GRND_NONBLOCK) = 2496
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/socket.py", {st_mode=S_IFREG|0644, st_size=27443, ...}) = 0
+stat("/usr/lib64/python3.6/socket.py", {st_mode=S_IFREG|0644, st_size=27443, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/socket.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=22013, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=22013, ...}) = 0
+read(4, "3\r\r\n\243\344NZ3k\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 22014) = 22013
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_socket.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=123256, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_socket.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0;\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=123256, ...}) = 0
+mmap(NULL, 2218800, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f358fb27000
+mprotect(0x7f358fb40000, 2093056, PROT_NONE) = 0
+mmap(0x7f358fd3f000, 24576, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0x18000) = 0x7f358fd3f000
+close(4)                                = 0
+mprotect(0x7f358fd3f000, 4096, PROT_READ) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/urllib/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4b5c0) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/urllib/__init__.abi3.so", 0x7fff95b4b5c0) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/urllib/__init__.so", 0x7fff95b4b5c0) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/urllib/__init__.py", {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
+stat("/usr/lib64/python3.6/urllib/__init__.py", {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/urllib/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=113, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=113, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\0\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\1\0\0\0@\0\0"..., 114) = 113
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/urllib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/urllib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/urllib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib64/python3.6/urllib", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 280
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/urllib/parse.py", {st_mode=S_IFREG|0644, st_size=36603, ...}) = 0
+stat("/usr/lib64/python3.6/urllib/parse.py", {st_mode=S_IFREG|0644, st_size=36603, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/urllib/__pycache__/parse.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=29382, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=29382, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\373\216\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\31\0\0\0@\0\0"..., 29383) = 29382
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcdcf000)                     = 0x5648fcdcf000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3590a12000
+stat("/usr/lib64/python3.6/email", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/email/_parseaddr.py", {st_mode=S_IFREG|0644, st_size=17199, ...}) = 0
+stat("/usr/lib64/python3.6/email/_parseaddr.py", {st_mode=S_IFREG|0644, st_size=17199, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/email/__pycache__/_parseaddr.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=12434, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=12434, ...}) = 0
+read(4, "3\r\r\n\244\344NZ/C\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\30\0\0\0@\0\0"..., 12435) = 12434
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/calendar.py", {st_mode=S_IFREG|0644, st_size=23213, ...}) = 0
+stat("/usr/lib64/python3.6/calendar.py", {st_mode=S_IFREG|0644, st_size=23213, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/calendar.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=25882, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=25882, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\255Z\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\30\0\0\0@\0\0"..., 25883) = 25882
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/locale.py", {st_mode=S_IFREG|0644, st_size=74724, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/locale.py", {st_mode=S_IFREG|0644, st_size=74724, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/locale.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=33047, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=33047, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\344#\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0008\2\0\0@\0\0"..., 33048) = 33047
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358fae7000
+munmap(0x7f358fae7000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358fae7000
+munmap(0x7f358fae7000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358fae7000
+munmap(0x7f358fae7000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358fae7000
+munmap(0x7f358fae7000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358fae7000
+munmap(0x7f358fae7000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358fae7000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/tempfile.py", {st_mode=S_IFREG|0644, st_size=26635, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/tempfile.py", {st_mode=S_IFREG|0644, st_size=26635, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/tempfile.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=22163, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=22163, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\vh\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\20\0\0\0@\0\0"..., 22164) = 22163
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/textwrap.py", {st_mode=S_IFREG|0644, st_size=19558, ...}) = 0
+stat("/usr/lib64/python3.6/textwrap.py", {st_mode=S_IFREG|0644, st_size=19558, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/textwrap.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=13684, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=13684, ...}) = 0
+read(4, "3\r\r\n\243\344NZfL\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 13685) = 13684
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/inspect.py", {st_mode=S_IFREG|0644, st_size=115840, ...}) = 0
+stat("/usr/lib64/python3.6/inspect.py", {st_mode=S_IFREG|0644, st_size=115840, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/inspect.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=79029, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=79029, ...}) = 0
+brk(0x5648fcdfd000)                     = 0x5648fcdfd000
+read(4, "3\r\r\n\243\344NZ\200\304\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0\f\0\0\0@\0\0"..., 79030) = 79029
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358faa7000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/ast.py", {st_mode=S_IFREG|0644, st_size=12166, ...}) = 0
+stat("/usr/lib64/python3.6/ast.py", {st_mode=S_IFREG|0644, st_size=12166, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/ast.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11704, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11704, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\206/\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 11705) = 11704
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/dis.py", {st_mode=S_IFREG|0644, st_size=18132, ...}) = 0
+stat("/usr/lib64/python3.6/dis.py", {st_mode=S_IFREG|0644, st_size=18132, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/dis.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=14181, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=14181, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\324F\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 14182) = 14181
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/opcode.py", {st_mode=S_IFREG|0644, st_size=5833, ...}) = 0
+stat("/usr/lib64/python3.6/opcode.py", {st_mode=S_IFREG|0644, st_size=5833, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/opcode.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=5413, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=5413, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\311\26\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\24\0\0\0@\0\0"..., 5414) = 5413
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_opcode.cpython-36m-x86_64-linux-gnu.so", {st_mode=S_IFREG|0755, st_size=6032, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload/_opcode.cpython-36m-x86_64-linux-gnu.so", O_RDONLY|O_CLOEXEC) = 4
+read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0`\10\0\0\0\0\0\0"..., 832) = 832
+fstat(4, {st_mode=S_IFREG|0755, st_size=6032, ...}) = 0
+mmap(NULL, 2101552, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 4, 0) = 0x7f358f8a5000
+mprotect(0x7f358f8a6000, 2093056, PROT_NONE) = 0
+mmap(0x7f358faa5000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 4, 0) = 0x7f358faa5000
+close(4)                                = 0
+mprotect(0x7f358faa5000, 4096, PROT_READ) = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f865000
+brk(0x5648fce1f000)                     = 0x5648fce1f000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 7 entries */, 32768)     = 216
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4f840) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern/__init__.abi3.so", 0x7fff95b4f840) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern/__init__.so", 0x7fff95b4f840) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern/__init__.py", {st_mode=S_IFREG|0644, st_size=2487, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern/__init__.py", {st_mode=S_IFREG|0644, st_size=2487, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2382, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2382, ...}) = 0
+read(4, "3\r\r\nK\204kZ\267\t\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 2383) = 2382
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 4 entries */, 32768)     = 112
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4dbe0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__init__.abi3.so", 0x7fff95b4dbe0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__init__.so", 0x7fff95b4dbe0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__init__.py", {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__init__.py", {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=151, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=151, ...}) = 0
+read(4, "3\r\r\nK\204kZ\0\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\1\0\0\0@\0\0"..., 152) = 151
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 8 entries */, 32768)     = 240
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/six.py", {st_mode=S_IFREG|0644, st_size=30098, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/six.py", {st_mode=S_IFREG|0644, st_size=30098, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__pycache__/six.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=24448, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=24448, ...}) = 0
+read(4, "3\r\r\nK\204kZ\222u\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0I\0\0\0@\0\0"..., 24449) = 24448
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/six.py", {st_mode=S_IFREG|0644, st_size=30098, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/six.py", {st_mode=S_IFREG|0644, st_size=30098, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__pycache__/six.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=24448, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=24448, ...}) = 0
+read(4, "3\r\r\nK\204kZ\222u\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0I\0\0\0@\0\0"..., 24449) = 24448
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f825000
+munmap(0x7f358f825000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f825000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/py31compat.py", {st_mode=S_IFREG|0644, st_size=600, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/py31compat.py", {st_mode=S_IFREG|0644, st_size=600, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/__pycache__/py31compat.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=654, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=654, ...}) = 0
+read(4, "3\r\r\nK\204kZX\2\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 655) = 654
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/appdirs.py", {st_mode=S_IFREG|0644, st_size=22374, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/appdirs.py", {st_mode=S_IFREG|0644, st_size=22374, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__pycache__/appdirs.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=18577, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=18577, ...}) = 0
+read(4, "3\r\r\nK\204kZfW\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\33\0\0\0@\0\0"..., 18578) = 18577
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4e4a0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__init__.abi3.so", 0x7fff95b4e4a0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__init__.so", 0x7fff95b4e4a0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__init__.py", {st_mode=S_IFREG|0644, st_size=513, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__init__.py", {st_mode=S_IFREG|0644, st_size=513, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=525, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=525, ...}) = 0
+read(4, "3\r\r\nK\204kZ\1\2\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\10\0\0\0@\0\0"..., 526) = 525
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 12 entries */, 32768)    = 392
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__about__.py", {st_mode=S_IFREG|0644, st_size=720, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__about__.py", {st_mode=S_IFREG|0644, st_size=720, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/__about__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=687, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=687, ...}) = 0
+read(4, "3\r\r\nK\204kZ\320\2\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\10\0\0\0@\0\0"..., 688) = 687
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/version.py", {st_mode=S_IFREG|0644, st_size=11556, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/version.py", {st_mode=S_IFREG|0644, st_size=11556, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/version.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=10566, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=10566, ...}) = 0
+read(4, "3\r\r\nK\204kZ$-\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\10\0\0\0@\0\0"..., 10567) = 10566
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/_structures.py", {st_mode=S_IFREG|0644, st_size=1416, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/_structures.py", {st_mode=S_IFREG|0644, st_size=1416, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/_structures.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2829, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2829, ...}) = 0
+read(4, "3\r\r\nK\204kZ\210\5\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 2830) = 2829
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fce41000)                     = 0x5648fce41000
+brk(0x5648fce62000)                     = 0x5648fce62000
+brk(0x5648fce32000)                     = 0x5648fce32000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/specifiers.py", {st_mode=S_IFREG|0644, st_size=28025, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/specifiers.py", {st_mode=S_IFREG|0644, st_size=28025, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/specifiers.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=19791, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=19791, ...}) = 0
+read(4, "3\r\r\nK\204kZym\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 19792) = 19791
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/_compat.py", {st_mode=S_IFREG|0644, st_size=860, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/_compat.py", {st_mode=S_IFREG|0644, st_size=860, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/_compat.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=972, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=972, ...}) = 0
+read(4, "3\r\r\nK\204kZ\\\3\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\2\0\0\0@\0\0"..., 973) = 972
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+brk(0x5648fce5d000)                     = 0x5648fce5d000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/requirements.py", {st_mode=S_IFREG|0644, st_size=4355, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/requirements.py", {st_mode=S_IFREG|0644, st_size=4355, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/requirements.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=3848, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=3848, ...}) = 0
+read(4, "3\r\r\nK\204kZ\3\21\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\5\0\0\0@\0\0"..., 3849) = 3848
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/extern", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/__pycache__/pyparsing.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=201073, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=201073, ...}) = 0
+read(4, "3\r\r\nK\204kZ\353\201\3\0\343\0\0\0\0\0\0\0\0\0\0\0\0\177\0\0\0@\0\0"..., 201074) = 201073
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 204800, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f35944bb000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+munmap(0x7f358f7e5000, 262144)          = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7e5000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f7a5000
+brk(0x5648fce7e000)                     = 0x5648fce7e000
+munmap(0x7f35944bb000, 204800)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/copy.py", {st_mode=S_IFREG|0644, st_size=8815, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/copy.py", {st_mode=S_IFREG|0644, st_size=8815, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/copy.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=7111, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=7111, ...}) = 0
+read(4, "3\r\r\n\243\344NZo\"\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\31\0\0\0@\0\0"..., 7112) = 7111
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/pprint.py", {st_mode=S_IFREG|0644, st_size=20860, ...}) = 0
+stat("/usr/lib64/python3.6/pprint.py", {st_mode=S_IFREG|0644, st_size=20860, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/pprint.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=15824, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=15824, ...}) = 0
+read(4, "3\r\r\n\243\344NZ|Q\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\n\0\0\0@\0\0"..., 15825) = 15824
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4c4b0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+read(4, "# module pyparsing.py\r\n#\r\n# Copy"..., 4096) = 4096
+lseek(4, 0, SEEK_CUR)                   = 4096
+read(4, "To', 'StringEnd', 'StringStart',"..., 8192) = 8192
+read(4, "of access to the parsed data:\r\n "..., 8192) = 8192
+read(4, "has)\r\n            patt = label(\""..., 8192) = 8192
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f765000
+read(4, "is not JSON serializable\r\n      "..., 8192) = 8192
+read(4, "ent = wkref(par)\r\n        else:\r"..., 8192) = 8192
+read(4, "report only last) or cumulative "..., 8192) = 8192
+read(4, " was attempted and failed\r\n     "..., 8192) = 8192
+read(4, "e = cache.get(lookup)\r\n         "..., 8192) = 8192
+read(4, " that may\r\n        be returned f"..., 8192) = 8192
+read(4, "her[0]),type(other[1]))\r\n       "..., 8192) = 8192
+read(4, "       Matched alphaword -> ['ab"..., 8192) = 8192
+read(4, "on as pe:\r\n                fatal"..., 8192) = 8192
+read(4, "lf.errmsg, self)\r\n\r\nclass CloseM"..., 8192) = 8192
+read(4, "ion = False\r\n        if loc - st"..., 8192) = 8192
+read(4, "       self.name = _ustr(self)\r\n"..., 8192) = 8192
+read(4, ",self).__init__()\r\n        self."..., 8192) = 8192
+read(4, "ger(\"age\")])\r\n        # more eas"..., 8192) = 8192
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f725000
+read(4, "space.\r\n    May be constructed u"..., 8192) = 8192
+read(4, "lowedBy(':')\r\n        attr_expr "..., 8192) = 8192
+read(4, "arget expression marking the end"..., 8192) = 8192
+read(4, "ter):\r\n    \"\"\"\r\n    Converter to"..., 8192) = 8192
+read(4, "bal helpers\r\n#\r\ndef delimitedLis"..., 8192) = 8192
+read(4, "OrMore}}, and C{L{Group}} tokens"..., 8192) = 8192
+read(4, " are passed, they are forwarded "..., 8192) = 8192
+read(4, "   for grid_header in grid_expr."..., 8192) = 8192
+read(4, "e_body = nestedExpr('{', '}', ig"..., 8192) = 8192
+read(4, "hon style comment\")\r\n\"Comment of"..., 8192) = 8192
+read(4, "so8601_datetime.copy()\r\n        "..., 8192) = 4587
+read(4, "", 8192)                       = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f6e5000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+brk(0x5648fce9f000)                     = 0x5648fce9f000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/markers.py", {st_mode=S_IFREG|0644, st_size=8248, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/markers.py", {st_mode=S_IFREG|0644, st_size=8248, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/__pycache__/markers.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=8852, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=8852, ...}) = 0
+read(4, "3\r\r\nK\204kZ8 \0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\t\0\0\0@\0\0"..., 8853) = 8852
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f6a5000
+brk(0x5648fcecf000)                     = 0x5648fcecf000
+brk(0x5648fcef0000)                     = 0x5648fcef0000
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", {st_mode=S_IFREG|0644, st_size=229867, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/sysconfig.py", {st_mode=S_IFREG|0644, st_size=24861, ...}) = 0
+stat("/usr/lib64/python3.6/sysconfig.py", {st_mode=S_IFREG|0644, st_size=24861, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/sysconfig.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=15831, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=15831, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\35a\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 15832) = 15831
+read(4, "", 1)                          = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/bin/python3", {st_mode=S_IFREG|0755, st_size=10368, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/bin/Modules/Setup.dist", 0x7fff95b4f2d0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/bin/Modules/Setup.local", 0x7fff95b4f2d0) = -1 ENOENT (No such file or directory)
+uname({sysname="Linux", nodename="freon", ...}) = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/bin", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 46 entries */, 32768)    = 1480
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/.local", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/.local/lib", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+lstat("/home/sangaline/.local/lib/python3.6", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+lstat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getdents(4, /* 68 entries */, 32768)    = 2744
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/xlrd-1.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/xlrd-1.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/widgetsnbextension-3.0.6.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/widgetsnbextension-3.0.6.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/when_changed-0.3.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/when_changed-0.3.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/uritemplate-3.0.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/uritemplate-3.0.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/testpath-0.3.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/testpath-0.3.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 7 entries */, 32768)     = 208
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/TermRecord-1.2.5.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/TermRecord-1.2.5.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/resampy-0.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/resampy-0.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/qtconsole-4.3.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/qtconsole-4.3.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/python_utils-2.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/python_utils-2.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1-0.3.7.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1-0.3.7.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1_modules-0.1.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1_modules-0.1.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/progressbar2-3.34.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/progressbar2-3.34.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/oauth2client-4.1.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/oauth2client-4.1.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/numba-0.35.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/numba-0.35.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/notebook-5.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/notebook-5.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/mistune-0.8.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/mistune-0.8.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info/PKG-INFO", {st_mode=S_IFREG|0644, st_size=4595, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info/PKG-INFO", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4595, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4ecc0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4595, ...}) = 0
+read(4, "Metadata-Version: 1.1\nName: lxml"..., 4596) = 4595
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/llvmlite-0.20.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/llvmlite-0.20.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/librosa-0.5.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/librosa-0.5.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/keystone_engine-0.9.1.post3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/keystone_engine-0.9.1.post3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/jupyter-1.0.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/jupyter-1.0.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipywidgets-7.0.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/ipywidgets-7.0.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipython_genutils-0.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/ipython_genutils-0.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipykernel-4.6.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/ipykernel-4.6.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/html5lib-1.0b10.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/html5lib-1.0b10.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/google_api_python_client-1.6.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/google_api_python_client-1.6.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/entrypoints-0.2.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/entrypoints-0.2.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 7 entries */, 32768)     = 208
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/capstone-3.0.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/capstone-3.0.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/binch-0.3.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/binch-0.3.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/audioread-2.1.5.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/audioread-2.1.5.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/appnope-0.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/appnope-0.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/tests", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/tests/data", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/tests/data/strace-output", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 3 entries */, 32768)     = 88
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+open("/home/sangaline", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+getdents(4, /* 589 entries */, 32768)   = 20008
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 57 entries */, 32768)    = 1928
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFLNK|0777, st_size=30, ...}) = 0
+readlink("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", "/usr/lib/python3.6/lib-dynload", 4096) = 30
+lstat("/usr", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/usr/lib", {st_mode=S_IFDIR|0755, st_size=270336, ...}) = 0
+lstat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/usr/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib/python3.6/lib-dynload", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 69 entries */, 32768)    = 4304
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/usr", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/usr/lib64", {st_mode=S_IFLNK|0777, st_size=3, ...}) = 0
+readlink("/usr/lib64", "lib", 4096)     = 3
+lstat("/usr/lib", {st_mode=S_IFDIR|0755, st_size=270336, ...}) = 0
+lstat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 208 entries */, 32768)   = 6912
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/usr", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/usr/lib", {st_mode=S_IFDIR|0755, st_size=270336, ...}) = 0
+lstat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 208 entries */, 32768)   = 6912
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 76 entries */, 32768)    = 2952
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/wheel-0.30.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/wheel-0.30.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 11 entries */, 32768)    = 368
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/watchdog-0.8.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/watchdog-0.8.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/virtualenv-15.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/virtualenv-15.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/urllib3-1.22.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/urllib3-1.22.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/twine-1.9.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/twine-1.9.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tqdm-4.19.5.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tqdm-4.19.5.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tox-2.9.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tox-2.9.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/termcolor-1.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/termcolor-1.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/six-1.11.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/six-1.11.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/setuptools-38.4.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/setuptools-38.4.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 13 entries */, 32768)    = 440
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests-2.18.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests-2.18.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests_toolbelt-0.8.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests_toolbelt-0.8.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/PyYAML-3.12.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/PyYAML-3.12.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest-3.2.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest-3.2.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 11 entries */, 32768)    = 368
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_watch-4.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_watch-4.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_sugar-0.9.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_sugar-0.9.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_console_scripts-0.1.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_console_scripts-0.1.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/py-1.4.34.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/py-1.4.34.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pluggy-0.5.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pluggy-0.5.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkginfo-1.4.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkginfo-1.4.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pip-9.0.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pip-9.0.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pbr-3.1.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pbr-3.1.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pathtools-0.1.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pathtools-0.1.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/mock-2.0.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/mock-2.0.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/m2r-0.1.12.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/m2r-0.1.12.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/idna-2.6.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/idna-2.6.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docutils-0.14.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docutils-0.14.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docopt-0.6.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docopt-0.6.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/colorama-0.3.9.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/colorama-0.3.9.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/chardet-3.0.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/chardet-3.0.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/certifi-2018.1.18.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/certifi-2018.1.18.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/bumpversion-0.5.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/bumpversion-0.5.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/argh-0.26.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/argh-0.26.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 5 entries */, 32768)     = 176
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus.egg-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src/exodus.egg-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 8 entries */, 32768)     = 264
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus.egg-info/PKG-INFO", {st_mode=S_IFREG|0644, st_size=822, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus.egg-info/PKG-INFO", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=822, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4ecc0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=822, ...}) = 0
+read(4, "Metadata-Version: 1.1\nName: exod"..., 823) = 822
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 8 entries */, 32768)     = 264
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/PKG-INFO", {st_mode=S_IFREG|0644, st_size=1519, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/PKG-INFO", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1519, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4ecc0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1519, ...}) = 0
+read(4, "Metadata-Version: 1.1\nName: exod"..., 1520) = 1519
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcf12000)                     = 0x5648fcf12000
+brk(0x5648fcf36000)                     = 0x5648fcf36000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f665000
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/requires.txt", 0x7fff95b4f160) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/depends.txt", 0x7fff95b4f160) = -1 ENOENT (No such file or directory)
+lstat("/usr", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/usr/lib", {st_mode=S_IFDIR|0755, st_size=270336, ...}) = 0
+lstat("/usr/lib/root", 0x7fff95b4f1e0)  = -1 ENOENT (No such file or directory)
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/.env/lib/python36.zip", 0x7fff95b4f1e0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/xlrd-1.1.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/widgetsnbextension-3.0.6.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/when_changed-0.3.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/uritemplate-3.0.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/testpath-0.3.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/TermRecord-1.2.5.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/resampy-0.2.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/qtconsole-4.3.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/python_utils-2.2.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1-0.3.7.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1_modules-0.1.4.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/progressbar2-3.34.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/oauth2client-4.1.2.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/numba-0.35.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/notebook-5.2.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/mistune-0.8.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/llvmlite-0.20.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/librosa-0.5.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/keystone_engine-0.9.1.post3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/jupyter-1.0.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipywidgets-7.0.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipython_genutils-0.2.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipykernel-4.6.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/html5lib-1.0b10.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/google_api_python_client-1.6.4.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/entrypoints-0.2.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/capstone-3.0.4.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/binch-0.3.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/audioread-2.1.5.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/.local/lib/python3.6/site-packages/appnope-0.1.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/wheel-0.30.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/watchdog-0.8.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/virtualenv-15.1.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/urllib3-1.22.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/twine-1.9.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tqdm-4.19.5.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tox-2.9.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/termcolor-1.1.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/six-1.11.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/setuptools-38.4.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests-2.18.4.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests_toolbelt-0.8.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/PyYAML-3.12.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest-3.2.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_watch-4.1.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_sugar-0.9.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_console_scripts-0.1.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/py-1.4.34.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pluggy-0.5.2.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkginfo-1.4.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pip-9.0.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pbr-3.1.1.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pathtools-0.1.2.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/mock-2.0.0.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/m2r-0.1.12.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/idna-2.6.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docutils-0.14.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docopt-0.6.2.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/colorama-0.3.9.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/chardet-3.0.4.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/certifi-2018.1.18.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/bumpversion-0.5.3.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/argh-0.26.2.dist-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus.egg-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/namespace_packages.txt", 0x7fff95b4fc30) = -1 ENOENT (No such file or directory)
+open("/home/sangaline/projects/exodus/.env/bin", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 46 entries */, 32768)    = 1480
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+getdents(4, /* 68 entries */, 32768)    = 2744
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/xlrd-1.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/xlrd-1.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/widgetsnbextension-3.0.6.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/widgetsnbextension-3.0.6.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/when_changed-0.3.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/when_changed-0.3.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/uritemplate-3.0.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/uritemplate-3.0.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/testpath-0.3.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/testpath-0.3.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 7 entries */, 32768)     = 208
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/TermRecord-1.2.5.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/TermRecord-1.2.5.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/resampy-0.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/resampy-0.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/qtconsole-4.3.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/qtconsole-4.3.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/python_utils-2.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/python_utils-2.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1-0.3.7.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1-0.3.7.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1_modules-0.1.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/pyasn1_modules-0.1.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/progressbar2-3.34.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/progressbar2-3.34.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/oauth2client-4.1.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/oauth2client-4.1.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/numba-0.35.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/numba-0.35.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/notebook-5.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/notebook-5.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/mistune-0.8.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/mistune-0.8.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info/PKG-INFO", {st_mode=S_IFREG|0644, st_size=4595, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/.local/lib/python3.6/site-packages/lxml-3.8.0-py3.6.egg-info/PKG-INFO", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4595, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4f0b0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4595, ...}) = 0
+read(4, "Metadata-Version: 1.1\nName: lxml"..., 4596) = 4595
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/llvmlite-0.20.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/llvmlite-0.20.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/librosa-0.5.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/librosa-0.5.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/keystone_engine-0.9.1.post3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/keystone_engine-0.9.1.post3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/jupyter-1.0.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/jupyter-1.0.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipywidgets-7.0.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/ipywidgets-7.0.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipython_genutils-0.2.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/ipython_genutils-0.2.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/ipykernel-4.6.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/ipykernel-4.6.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/html5lib-1.0b10.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/html5lib-1.0b10.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/google_api_python_client-1.6.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/google_api_python_client-1.6.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/entrypoints-0.2.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/entrypoints-0.2.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 7 entries */, 32768)     = 208
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/capstone-3.0.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/capstone-3.0.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/binch-0.3.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/binch-0.3.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/audioread-2.1.5.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/audioread-2.1.5.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages/appnope-0.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/.local/lib/python3.6/site-packages/appnope-0.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/home/sangaline/projects/exodus/tests/data/strace-output", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 3 entries */, 32768)     = 88
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/home/sangaline", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+getdents(4, /* 589 entries */, 32768)   = 20008
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 57 entries */, 32768)    = 1928
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/usr/lib/python3.6/lib-dynload", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 69 entries */, 32768)    = 4304
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/usr/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 208 entries */, 32768)   = 6912
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/usr/lib/python3.6", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 208 entries */, 32768)   = 6912
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 76 entries */, 32768)    = 2952
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/wheel-0.30.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/wheel-0.30.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 11 entries */, 32768)    = 368
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/watchdog-0.8.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/watchdog-0.8.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/virtualenv-15.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/virtualenv-15.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/urllib3-1.22.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/urllib3-1.22.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/twine-1.9.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/twine-1.9.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tqdm-4.19.5.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tqdm-4.19.5.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tox-2.9.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/tox-2.9.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/termcolor-1.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/termcolor-1.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/six-1.11.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/six-1.11.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/setuptools-38.4.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/setuptools-38.4.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 13 entries */, 32768)    = 440
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests-2.18.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests-2.18.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests_toolbelt-0.8.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/requests_toolbelt-0.8.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/PyYAML-3.12.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/PyYAML-3.12.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest-3.2.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest-3.2.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 11 entries */, 32768)    = 368
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_watch-4.1.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_watch-4.1.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_sugar-0.9.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_sugar-0.9.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_console_scripts-0.1.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pytest_console_scripts-0.1.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/py-1.4.34.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/py-1.4.34.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pluggy-0.5.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pluggy-0.5.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkginfo-1.4.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pkginfo-1.4.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pip-9.0.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pip-9.0.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pbr-3.1.1.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pbr-3.1.1.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pathtools-0.1.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/pathtools-0.1.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/mock-2.0.0.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/mock-2.0.0.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/m2r-0.1.12.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/m2r-0.1.12.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/idna-2.6.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/idna-2.6.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docutils-0.14.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docutils-0.14.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docopt-0.6.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/docopt-0.6.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/colorama-0.3.9.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/colorama-0.3.9.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/chardet-3.0.4.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/chardet-3.0.4.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 336
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/certifi-2018.1.18.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/certifi-2018.1.18.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/bumpversion-0.5.3.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/bumpversion-0.5.3.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 10 entries */, 32768)    = 328
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/argh-0.26.2.dist-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages/argh-0.26.2.dist-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 9 entries */, 32768)     = 296
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+open("/home/sangaline/projects/exodus/src", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 5 entries */, 32768)     = 176
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus.egg-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src/exodus.egg-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 8 entries */, 32768)     = 264
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus.egg-info/PKG-INFO", {st_mode=S_IFREG|0644, st_size=822, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus.egg-info/PKG-INFO", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=822, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4f0b0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=822, ...}) = 0
+read(4, "Metadata-Version: 1.1\nName: exod"..., 823) = 822
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 8 entries */, 32768)     = 264
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/PKG-INFO", {st_mode=S_IFREG|0644, st_size=1519, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/PKG-INFO", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1519, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b4f0b0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1519, ...}) = 0
+read(4, "Metadata-Version: 1.1\nName: exod"..., 1520) = 1519
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/entry_points.txt", {st_mode=S_IFREG|0644, st_size=52, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler.egg-info/entry_points.txt", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=52, ...}) = 0
+ioctl(4, TCGETS, 0x7fff95b505f0)        = -1 ENOTTY (Inappropriate ioctl for device)
+lseek(4, 0, SEEK_CUR)                   = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=52, ...}) = 0
+read(4, "[console_scripts]\nexodus = exodu"..., 53) = 52
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/site-packages", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4f4e0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/__init__.abi3.so", 0x7fff95b4f4e0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/__init__.so", 0x7fff95b4f4e0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/__init__.py", {st_mode=S_IFREG|0644, st_size=129, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/__init__.py", {st_mode=S_IFREG|0644, st_size=129, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=273, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=273, ...}) = 0
+read(4, "3\r\r\n\327\267\211Z\201\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\2\0\0\0@\0\0"..., 274) = 273
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/logging/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4e670) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/logging/__init__.abi3.so", 0x7fff95b4e670) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/logging/__init__.so", 0x7fff95b4e670) = -1 ENOENT (No such file or directory)
+stat("/usr/lib64/python3.6/logging/__init__.py", {st_mode=S_IFREG|0644, st_size=71152, ...}) = 0
+stat("/usr/lib64/python3.6/logging/__init__.py", {st_mode=S_IFREG|0644, st_size=71152, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/logging/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=60270, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=60270, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\360\25\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0*\0\0\0@\0\0"..., 60271) = 60270
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/home/sangaline/projects/exodus/src/exodus_bundler", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 16 entries */, 32768)    = 520
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/cli.py", {st_mode=S_IFREG|0644, st_size=5255, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/cli.py", {st_mode=S_IFREG|0644, st_size=5255, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler/__pycache__/cli.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4636, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4636, ...}) = 0
+read(4, "3\r\r\ni\315\232Z\207\24\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 4637) = 4636
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/argparse.py", {st_mode=S_IFREG|0644, st_size=90268, ...}) = 0
+stat("/usr/lib64/python3.6/argparse.py", {st_mode=S_IFREG|0644, st_size=90268, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/argparse.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=60174, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=60174, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\234`\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0\21\0\0\0@\0\0"..., 60175) = 60174
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f625000
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/gettext.py", {st_mode=S_IFREG|0644, st_size=21530, ...}) = 0
+stat("/usr/lib64/python3.6/gettext.py", {st_mode=S_IFREG|0644, st_size=21530, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/gettext.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=14197, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=14197, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\32T\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\21\0\0\0@\0\0"..., 14198) = 14197
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/bundling.py", {st_mode=S_IFREG|0644, st_size=28217, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/bundling.py", {st_mode=S_IFREG|0644, st_size=28217, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler/__pycache__/bundling.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=21883, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=21883, ...}) = 0
+read(4, "3\r\r\nP\320\232Z9n\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 21884) = 21883
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 593920, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f594000
+munmap(0x7f359261f000, 299008)          = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/tarfile.py", {st_mode=S_IFREG|0755, st_size=93186, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/tarfile.py", {st_mode=S_IFREG|0755, st_size=93186, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/tarfile.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=62617, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=62617, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\2l\1\0\343\0\0\0\0\0\0\0\0\0\0\0\0'\0\0\0@\0\0"..., 62618) = 62617
+read(4, "", 1)                          = 0
+close(4)                                = 0
+brk(0x5648fcf59000)                     = 0x5648fcf59000
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f3592628000
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/errors.py", {st_mode=S_IFREG|0644, st_size=456, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/errors.py", {st_mode=S_IFREG|0644, st_size=456, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler/__pycache__/errors.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=1013, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=1013, ...}) = 0
+read(4, "3\r\r\ni\315\232Z\310\1\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 1014) = 1013
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/launchers.py", {st_mode=S_IFREG|0644, st_size=2550, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/launchers.py", {st_mode=S_IFREG|0644, st_size=2550, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler/__pycache__/launchers.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2512, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2512, ...}) = 0
+read(4, "3\r\r\n1\322\231Z\366\t\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 2513) = 2512
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/distutils/__init__.cpython-36m-x86_64-linux-gnu.so", 0x7fff95b4c990) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/distutils/__init__.abi3.so", 0x7fff95b4c990) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/distutils/__init__.so", 0x7fff95b4c990) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/distutils/__init__.py", {st_mode=S_IFREG|0644, st_size=3983, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/distutils/__init__.py", {st_mode=S_IFREG|0644, st_size=3983, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/distutils/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2841, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2841, ...}) = 0
+read(4, "3\r\r\nI\204kZ\217\17\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\24\0\0\0@\0\0"..., 2842) = 2841
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/imp.py", {st_mode=S_IFREG|0644, st_size=10669, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/imp.py", {st_mode=S_IFREG|0644, st_size=10669, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/.env/lib/python3.6/__pycache__/imp.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=9728, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=9728, ...}) = 0
+read(4, "3\r\r\n\243\344NZ\255)\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\r\0\0\0@\0\0"..., 9729) = 9728
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/__init__.py", {st_mode=S_IFREG|0644, st_size=236, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/__init__.py", {st_mode=S_IFREG|0644, st_size=236, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/__init__.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=366, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=366, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\354\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 367) = 366
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+open("/usr/lib64/python3.6/distutils", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
+fstat(4, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+getdents(4, /* 34 entries */, 32768)    = 1144
+getdents(4, /* 0 entries */, 32768)     = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils/dist.py", {st_mode=S_IFREG|0644, st_size=49690, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/dist.py", {st_mode=S_IFREG|0644, st_size=49690, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/dist.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=34128, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=34128, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\32\302\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 34129) = 34128
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/errors.py", {st_mode=S_IFREG|0644, st_size=3577, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/errors.py", {st_mode=S_IFREG|0644, st_size=3577, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/errors.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=5462, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=5462, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\371\r\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0@\0\0"..., 5463) = 5462
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/fancy_getopt.py", {st_mode=S_IFREG|0644, st_size=17784, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/fancy_getopt.py", {st_mode=S_IFREG|0644, st_size=17784, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/fancy_getopt.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=10641, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=10641, ...}) = 0
+read(4, "3\r\r\n\244\344NZxE\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\6\0\0\0@\0\0"..., 10642) = 10641
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/.local/lib/python3.6/site-packages", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/tests/data/strace-output", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/lib/python3.6/lib-dynload", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/getopt.py", {st_mode=S_IFREG|0644, st_size=7489, ...}) = 0
+stat("/usr/lib64/python3.6/getopt.py", {st_mode=S_IFREG|0644, st_size=7489, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/__pycache__/getopt.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=6217, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=6217, ...}) = 0
+read(4, "3\r\r\n\243\344NZA\35\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\16\0\0\0@\0\0"..., 6218) = 6217
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/util.py", {st_mode=S_IFREG|0644, st_size=20789, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/util.py", {st_mode=S_IFREG|0644, st_size=20789, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/util.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=15521, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=15521, ...}) = 0
+read(4, "3\r\r\n\244\344NZ5Q\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\7\0\0\0@\0\0"..., 15522) = 15521
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/dep_util.py", {st_mode=S_IFREG|0644, st_size=3491, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/dep_util.py", {st_mode=S_IFREG|0644, st_size=3491, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/dep_util.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2692, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2692, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\243\r\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 2693) = 2692
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/spawn.py", {st_mode=S_IFREG|0644, st_size=7411, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/spawn.py", {st_mode=S_IFREG|0644, st_size=7411, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/spawn.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=4961, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=4961, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\363\34\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 4962) = 4961
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/debug.py", {st_mode=S_IFREG|0644, st_size=139, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/debug.py", {st_mode=S_IFREG|0644, st_size=139, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/debug.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=176, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=176, ...}) = 0
+read(4, "3\r\r\n\244\344NZ\213\0\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\2\0\0\0@\0\0"..., 177) = 176
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/log.py", {st_mode=S_IFREG|0644, st_size=1908, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/log.py", {st_mode=S_IFREG|0644, st_size=1908, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/log.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=2249, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=2249, ...}) = 0
+read(4, "3\r\r\n\244\344NZt\7\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 2250) = 2249
+read(4, "", 1)                          = 0
+close(4)                                = 0
+mmap(NULL, 262144, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f358f554000
+stat("/usr/lib64/python3.6/distutils", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/sysconfig.py", {st_mode=S_IFREG|0644, st_size=20061, ...}) = 0
+stat("/usr/lib64/python3.6/distutils/sysconfig.py", {st_mode=S_IFREG|0644, st_size=20061, ...}) = 0
+openat(AT_FDCWD, "/usr/lib64/python3.6/distutils/__pycache__/sysconfig.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=11867, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=11867, ...}) = 0
+read(4, "3\r\r\n\244\344NZ]N\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\v\0\0\0@\0\0"..., 11868) = 11867
+read(4, "", 1)                          = 0
+close(4)                                = 0
+stat("/home/sangaline/projects/exodus/.env/bin/Modules/Setup.dist", 0x7fff95b4b550) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/bin/Modules/Setup.local", 0x7fff95b4b550) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/templating.py", {st_mode=S_IFREG|0644, st_size=730, ...}) = 0
+stat("/home/sangaline/projects/exodus/src/exodus_bundler/templating.py", {st_mode=S_IFREG|0644, st_size=730, ...}) = 0
+openat(AT_FDCWD, "/home/sangaline/projects/exodus/src/exodus_bundler/__pycache__/templating.cpython-36.pyc", O_RDONLY|O_CLOEXEC) = 4
+fstat(4, {st_mode=S_IFREG|0644, st_size=923, ...}) = 0
+lseek(4, 0, SEEK_CUR)                   = 0
+fstat(4, {st_mode=S_IFREG|0644, st_size=923, ...}) = 0
+read(4, "3\r\r\n\374\205oZ\332\2\0\0\343\0\0\0\0\0\0\0\0\0\0\0\0\3\0\0\0@\0\0"..., 924) = 923
+read(4, "", 1)                          = 0
+close(4)                                = 0
+lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline", {st_mode=S_IFDIR|0700, st_size=20480, ...}) = 0
+lstat("/home/sangaline/projects", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/src", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/src/exodus_bundler", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
+lstat("/home/sangaline/projects/exodus/src/exodus_bundler/templating.py", {st_mode=S_IFREG|0644, st_size=730, ...}) = 0
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en/LC_MESSAGES/messages.mo", 0x7fff95b50810) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b504b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US/LC_MESSAGES/messages.mo", 0x7fff95b504b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b504b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en/LC_MESSAGES/messages.mo", 0x7fff95b504b0) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b4f420) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US/LC_MESSAGES/messages.mo", 0x7fff95b4f420) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b4f420) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en/LC_MESSAGES/messages.mo", 0x7fff95b4f420) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50300) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en_US/LC_MESSAGES/messages.mo", 0x7fff95b50300) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en.UTF-8/LC_MESSAGES/messages.mo", 0x7fff95b50300) = -1 ENOENT (No such file or directory)
+stat("/home/sangaline/projects/exodus/.env/share/locale/en/LC_MESSAGES/messages.mo", 0x7fff95b50300) = -1 ENOENT (No such file or directory)
+write(2, "usage: exodus [-h] [-c CHROOT_PA"..., 220usage: exodus [-h] [-c CHROOT_PATH] [-a DEPENDENCY] [-o OUTPUT_FILE] [-q]
+              [-r [NEW_NAME]] [-t] [-v]
+              EXECUTABLE [EXECUTABLE ...]
+exodus: error: the following arguments are required: EXECUTABLE
+) = 220
+rt_sigaction(SIGINT, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, {sa_handler=0x7f3593b3b400, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f3594286dd0}, 8) = 0
+munmap(0x7f358f765000, 262144)          = 0
+munmap(0x7f358f554000, 262144)          = 0
+sigaltstack(NULL, {ss_sp=0x5648fcc406f0, ss_flags=0, ss_size=8192}) = 0
+sigaltstack({ss_sp=NULL, ss_flags=SS_DISABLE, ss_size=0}, NULL) = 0
+futex(0x7f35909ef42c, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+exit_group(2)                           = ?
++++ exited with 2 +++

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -8,6 +8,11 @@ strace_output_directory = os.path.join(parent_directory, 'data', 'strace-output'
 exodus_strace = os.path.join(strace_output_directory, 'exodus-output.txt')
 
 
+def test_extract_no_filenames():
+    input_filenames = extract_filenames('')
+    assert input_filenames == [], 'It should return an empty list.'
+
+
 def test_extract_raw_filenames():
     input_filenames = [
         '/absolute/path/to/file',

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -1,7 +1,7 @@
 import os
 
-from exodus_bundler.input_parsing import extract_exec_filename
-from exodus_bundler.input_parsing import extract_filenames
+from exodus_bundler.input_parsing import extract_exec_path
+from exodus_bundler.input_parsing import extract_paths
 
 
 parent_directory = os.path.dirname(os.path.realpath(__file__))
@@ -9,41 +9,41 @@ strace_output_directory = os.path.join(parent_directory, 'data', 'strace-output'
 exodus_strace = os.path.join(strace_output_directory, 'exodus-output.txt')
 
 
-def test_extract_exec_filename():
+def test_extract_exec_path():
     line = 'execve("/usr/bin/ls", ["ls"], 0x7ffea775ad70 /* 113 vars */) = 0'
-    assert extract_exec_filename(line) == '/usr/bin/ls', \
+    assert extract_exec_path(line) == '/usr/bin/ls', \
         'It should have extracted the path to the ls executable.'
-    assert extract_exec_filename('blah') is None, \
+    assert extract_exec_path('blah') is None, \
         'It should return `None` when there is no match.'
 
 
-def test_extract_no_filenames():
-    input_filenames = extract_filenames('')
-    assert input_filenames == [], 'It should return an empty list.'
+def test_extract_no_paths():
+    input_paths = extract_paths('')
+    assert input_paths == [], 'It should return an empty list.'
 
 
-def test_extract_raw_filenames():
-    input_filenames = [
+def test_extract_raw_paths():
+    input_paths = [
         '/absolute/path/to/file',
         './relative/path',
         '/another/absolute/path',
     ]
-    input_filenames_with_whitespace = \
-        ['  ', ''] + [input_filenames[0]] + [' '] + input_filenames[1:]
-    input_content = '\n'.join(input_filenames_with_whitespace)
-    extracted_filenames = extract_filenames(input_content)
-    assert set(input_filenames) == set(extracted_filenames), \
-        'The filenames should have been extracted without the whitespace.'
+    input_paths_with_whitespace = \
+        ['  ', ''] + [input_paths[0]] + [' '] + input_paths[1:]
+    input_content = '\n'.join(input_paths_with_whitespace)
+    extracted_paths = extract_paths(input_content)
+    assert set(input_paths) == set(extracted_paths), \
+        'The paths should have been extracted without the whitespace.'
 
-def test_extract_strace_filenames():
+def test_extract_strace_paths():
     with open(exodus_strace, 'r') as f:
         content = f.read()
-    extracted_filenames = extract_filenames(content)
-    expected_filenames = [
+    extracted_paths = extract_paths(content)
+    expected_paths = [
         # `execve()` call
         '/home/sangaline/projects/exodus/.env/bin/exodus',
     ]
 
-    for filename in expected_filenames:
-        assert filename in extracted_filenames, \
-            '"%s" should be present in the extracted filenames.' % filename
+    for path in expected_paths:
+        assert path in extracted_paths, \
+            '"%s" should be present in the extracted paths.' % path

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -1,11 +1,20 @@
 import os
 
+from exodus_bundler.input_parsing import extract_exec_filename
 from exodus_bundler.input_parsing import extract_filenames
 
 
 parent_directory = os.path.dirname(os.path.realpath(__file__))
 strace_output_directory = os.path.join(parent_directory, 'data', 'strace-output')
 exodus_strace = os.path.join(strace_output_directory, 'exodus-output.txt')
+
+
+def test_extract_exec_filename():
+    line = 'execve("/usr/bin/ls", ["ls"], 0x7ffea775ad70 /* 113 vars */) = 0'
+    assert extract_exec_filename(line) == '/usr/bin/ls', \
+        'It should have extracted the path to the ls executable.'
+    assert extract_exec_filename('blah') is None, \
+        'It should return `None` when there is no match.'
 
 
 def test_extract_no_filenames():

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -34,3 +34,16 @@ def test_extract_raw_filenames():
     extracted_filenames = extract_filenames(input_content)
     assert set(input_filenames) == set(extracted_filenames), \
         'The filenames should have been extracted without the whitespace.'
+
+def test_extract_strace_filenames():
+    with open(exodus_strace, 'r') as f:
+        content = f.read()
+    extracted_filenames = extract_filenames(content)
+    expected_filenames = [
+        # `execve()` call
+        '/home/sangaline/projects/exodus/.env/bin/exodus',
+    ]
+
+    for filename in expected_filenames:
+        assert filename in extracted_filenames, \
+            '"%s" should be present in the extracted filenames.' % filename

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -52,6 +52,7 @@ def test_extract_raw_paths():
     assert set(input_paths) == set(extracted_paths), \
         'The paths should have been extracted without the whitespace.'
 
+
 def test_extract_strace_paths():
     with open(exodus_strace, 'r') as f:
         content = f.read()
@@ -59,6 +60,10 @@ def test_extract_strace_paths():
     expected_paths = [
         # `execve()` call
         '/home/sangaline/projects/exodus/.env/bin/exodus',
+        # `openat()` call
+        '/usr/lib/libpthread.so.0',
+        # `open()` call
+        '/usr/lib/gconv/gconv-modules',
     ]
 
     for path in expected_paths:

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -1,0 +1,22 @@
+import os
+
+from exodus_bundler.input_parsing import extract_filenames
+
+
+parent_directory = os.path.dirname(os.path.realpath(__file__))
+strace_output_directory = os.path.join(parent_directory, 'data', 'strace-output')
+exodus_strace = os.path.join(strace_output_directory, 'exodus-output.txt')
+
+
+def test_extract_raw_filenames():
+    input_filenames = [
+        '/absolute/path/to/file',
+        './relative/path',
+        '/another/absolute/path',
+    ]
+    input_filenames_with_whitespace = \
+        ['  ', ''] + [input_filenames[0]] + [' '] + input_filenames[1:]
+    input_content = '\n'.join(input_filenames_with_whitespace)
+    extracted_filenames = extract_filenames(input_content)
+    assert set(input_filenames) == set(extracted_filenames), \
+        'The filenames should have been extracted without the whitespace.'

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -1,6 +1,7 @@
 import os
 
 from exodus_bundler.input_parsing import extract_exec_path
+from exodus_bundler.input_parsing import extract_open_path
 from exodus_bundler.input_parsing import extract_paths
 
 
@@ -20,6 +21,22 @@ def test_extract_exec_path():
 def test_extract_no_paths():
     input_paths = extract_paths('')
     assert input_paths == [], 'It should return an empty list.'
+
+
+def test_extract_open_path():
+    line = (
+        'openat(AT_FDCWD, "/usr/lib/root/tls/x86_64/libcap.so.2", O_RDONLY|O_CLOEXEC) '
+        '= -1 ENOENT (No such file or directory)'
+    )
+    assert extract_open_path(line) is None, 'Missing files should not return paths.'
+    line = 'open(".", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4'
+    assert extract_open_path(line) is None, 'Opened directories should not return paths.'
+    line = 'open("/usr/lib/locale/locale-archive", O_RDONLY|O_CLOEXEC) = 4'
+    assert extract_open_path(line) == '/usr/lib/locale/locale-archive', \
+        'An open() call should return a path.'
+    line = 'openat(AT_FDCWD, "/usr/lib/libc.so.6", O_RDONLY|O_CLOEXEC) = 4'
+    assert extract_open_path(line) == '/usr/lib/libc.so.6', \
+        'An openat() call relative to the current directory should return a path.'
 
 
 def test_extract_raw_paths():


### PR DESCRIPTION

This extends the stdin parsing to allow for strace inputs. For example, you could run

```bash
strace nmap -sV localhost 2>&1 | exodus nmap
```

and all of the files that nmap attempts to read will be included (*e.g.* lua scripts).
