### PR TITLE
Add a factory for creating or retrieving files in a bundle

### DIFF
--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -675,7 +675,19 @@ class Bundle(object):
 
         See the `File.__init__()` method for documentation of the arguments, they're identical.
         """
-        # TODO: The actual deduplication.
+        # Attempt to find an existing file with the same normalize path in `self.files`.
+        path = resolve_file_path(path, search_environment_path=entry_point is not None)
+        file = next((file for file in self.files if file.path == path), None)
+        if file is not None:
+            assert entry_point == file.entry_point or not entry_point or not file.entry_point, \
+                'The entry point property should always persist, but can\'t conflict.'
+            file.entry_point = file.entry_point or entry_point
+            assert chroot == file.chroot, 'The chroot must match.'
+            file.library = file.library or library
+            assert not file.entry_point or not file.library, \
+                'A file can\'t be both an entry point and a library.'
+            return file
+
         return File(path, entry_point, chroot, library, file_factory)
 
     @property

--- a/tests/test_bundling.py
+++ b/tests/test_bundling.py
@@ -68,6 +68,16 @@ def test_bundle_delete_working_directory():
         'The working directory should have been cleared after deletion.'
 
 
+def test_bundle_file_factory():
+    bundle = Bundle()
+    bundle.add_file(ldd)
+    # Note that `ldd` is a shell script, and should bring in no dependencies.
+    [file] = bundle.files
+    new_file = bundle.file_factory(ldd)
+    assert new_file is file, \
+        'The same file should be returned instead of making a new one.'
+
+
 def test_bundle_hash():
     bundle = Bundle(chroot=chroot)
     hashes = [bundle.hash]

--- a/tests/test_bundling.py
+++ b/tests/test_bundling.py
@@ -13,6 +13,7 @@ from exodus_bundler.bundling import create_unpackaged_bundle
 from exodus_bundler.bundling import detect_elf_binary
 from exodus_bundler.bundling import parse_dependencies_from_ldd_output
 from exodus_bundler.bundling import resolve_binary
+from exodus_bundler.bundling import resolve_file_path
 from exodus_bundler.bundling import run_ldd
 from exodus_bundler.bundling import stored_property
 
@@ -285,6 +286,15 @@ def test_resolve_binary():
             'The full binary path was not resolved correctly.'
     finally:
         os.environ['PATH'] = old_path
+
+
+def test_resolve_file_path():
+    with pytest.raises(Exception):
+        resolve_file_path(chroot)
+    with pytest.raises(Exception):
+        resolve_file_path(os.path.join(chroot, 'non-existent-file'))
+    assert os.path.isabs(resolve_file_path(fizz_buzz_glibc_32)), \
+        'The resolved path should be absolute.'
 
 
 def test_run_ldd():


### PR DESCRIPTION
This avoids the creation of `File` instances when equivalent files already exist in a bundle. Additionally, it centralizes the logic for merging file properties and adds assertions for conflicting situations.
