### PR TITLE
Add support for non-GNU linkers

### DIFF
--- a/src/exodus_bundler/launchers.py
+++ b/src/exodus_bundler/launchers.py
@@ -88,16 +88,18 @@ def compile_musl(code):
     return compile_helper(code, [musl])
 
 
-def construct_bash_launcher(linker, library_path, executable):
+def construct_bash_launcher(linker, library_path, executable, full_linker=True):
     linker_dirname, linker_basename = os.path.split(linker)
+    full_linker = 'true' if full_linker else 'false'
     return render_template_file('launcher.sh', linker_basename=linker_basename,
                                 linker_dirname=linker_dirname, library_path=library_path,
-                                executable=executable)
+                                executable=executable, full_linker=full_linker)
 
 
-def construct_binary_launcher(linker, library_path, executable):
+def construct_binary_launcher(linker, library_path, executable, full_linker=True):
     linker_dirname, linker_basename = os.path.split(linker)
+    full_linker = '1' if full_linker else '0'
     code = render_template_file('launcher.c', linker_basename=linker_basename,
                                 linker_dirname=linker_dirname, library_path=library_path,
-                                executable=executable)
+                                executable=executable, full_linker=full_linker)
     return compile(code)

--- a/src/exodus_bundler/templates/launcher.sh
+++ b/src/exodus_bundler/templates/launcher.sh
@@ -5,4 +5,8 @@ executable="${current_directory}/{{executable}}"
 library_path="{{library_path}}"
 library_path="${current_directory}/${library_path//:/:${current_directory}/}"
 linker="${current_directory}/{{linker_dirname}}/{{linker_basename}}"
-exec "${linker}" --library-path "${library_path}" --inhibit-rpath "" "${executable}" "$@"
+if [ "{{full_linker}}" == "true" ]; then
+    exec "${linker}" --library-path "${library_path}" --inhibit-rpath "" "${executable}" "$@"
+else
+    exec "${linker}" --library-path "${library_path}" "${executable}" "$@"
+fi

--- a/tests/test_bundling.py
+++ b/tests/test_bundling.py
@@ -112,18 +112,22 @@ def test_bytes_to_int(int, bytes, byteorder):
     assert bytes_to_int(bytes, byteorder=byteorder) == int, 'Byte conversion should work.'
 
 
-@pytest.mark.parametrize('fizz_buzz', [
-    (fizz_buzz_glibc_32),
-    (fizz_buzz_glibc_64),
+@pytest.mark.parametrize('fizz_buzz,shell_launchers', [
+    (fizz_buzz_glibc_32, True),
+    (fizz_buzz_glibc_32, False),
+    (fizz_buzz_glibc_64, True),
+    (fizz_buzz_glibc_64, False),
+    (fizz_buzz_musl_64, True),
+    (fizz_buzz_musl_64, False),
 ])
-def test_create_unpackaged_bundle(fizz_buzz):
+def test_create_unpackaged_bundle(fizz_buzz, shell_launchers):
     """This tests that the packaged executable runs as expected. At the very least, this
     tests that the symbolic links and launcher are functioning correctly. Unfortunately,
     it doesn't really test the linker overrides unless the required libraries are not
     present on the current system. FWIW, the CircleCI docker image being used is
     incompatible, so the continuous integration tests are more meaningful."""
     root_directory = create_unpackaged_bundle(
-        rename=[], executables=[fizz_buzz], chroot=chroot)
+        rename=[], executables=[fizz_buzz], chroot=chroot, shell_launchers=shell_launchers)
     try:
         binary_path = os.path.join(root_directory, 'bin', os.path.basename(fizz_buzz))
 


### PR DESCRIPTION
This detects whether a linker supports the `--inhibit-rpath` option and then
uses a limit subset of the arguments if not. This is the last piece of the
puzzle in supporting binaries that use the musl linker.
