### PR TITLE
Add a `--detect` flag for auto-detecting package dependencies

### DIFF
--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -783,7 +783,7 @@ class Bundle(object):
 
         See the `File.__init__()` method for documentation of the arguments, they're identical.
         """
-        # Attempt to find an existing file with the same normalize path in `self.files`.
+        # Attempt to find an existing file with the same normalized path in `self.files`.
         path = resolve_file_path(path, search_environment_path=entry_point is not None)
         file = next((file for file in self.files if file.path == path), None)
         if file is not None:

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -124,7 +124,7 @@ def create_unpackaged_bundle(executables, rename=[], chroot=None, add=[], no_sym
                         'is not tracked by your package manager, or your operating system '
                         'is not currently compatible with the `--detect` option. If not, please '
                         'create an issue at https://github.com/intoli/exodus and we\'ll try our '
-                        ' to add support for it in the future.'
+                        ' to add support for it in the future.',
                     )
 
                 for path in dependency_paths:

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -679,6 +679,8 @@ class Bundle(object):
                 Directories will be included recursively for non-entry point dependencies.
             entry_point (string, optional): The name of the bundle entry point for an executable.
                 If `True`, the executable's basename will be used.
+        Returns:
+            The `File` that was added, or `None` if it was a directory that was added recursively.
         """
         try:
             file = self.file_factory(path, entry_point=entry_point, chroot=self.chroot)
@@ -693,6 +695,8 @@ class Bundle(object):
         self.files.add(file)
         if file.elf:
             self.files |= file.elf.dependencies
+
+        return file
 
     def create_bundle(self, shell_launchers=False):
         """Creates the unpackaged bundle in `working_directory`.

--- a/src/exodus_bundler/cli.py
+++ b/src/exodus_bundler/cli.py
@@ -44,6 +44,11 @@ def parse_args(args=None, namespace=None):
         ),
     )
 
+    parser.add_argument('-d', '--detect', action='store_true', help=(
+        'Attempt to autodetect direct dependencies using the system package manager. '
+        'Operating system support is limited.'
+    ))
+
     parser.add_argument('--no-symlink', metavar='FILE', action='append',
         default=[],
         help=(

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -10,6 +10,10 @@ def detect_dependencies(path):
     if dependencies:
         return dependencies
 
+    dependencies = detect_debian_dependencies(path)
+    if dependencies:
+        return dependencies
+
     return None
 
 
@@ -37,6 +41,37 @@ def detect_arch_dependencies(path):
         if not line.startswith(prefix):
             continue
         dependency_path = line[len(prefix):]
+        if os.path.exists(dependency_path):
+            dependencies.append(dependency_path)
+
+    return dependencies
+
+
+def detect_debian_dependencies(path):
+    cache_directory = '/var/cache/apt'
+    if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
+        return None
+
+    dpkg = resolve_binary('dpkg')
+    if not dpkg:
+        return None
+
+    process = subprocess.Popen([dpkg, '-S', path], stdout=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    parts = stdout.decode('utf-8').split(': ')
+    if len(parts) != 2:
+        return None
+
+    package_name = parts[0]
+    dpkg_query = resolve_binary('dpkg-query')
+    if not dpkg_query:
+        return None
+
+    package_name = parts[0]
+    process = subprocess.Popen([dpkg_query, '-L', package_name], stdout=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    dependencies = []
+    for dependency_path in stdout.decode('utf-8').split('\n'):
         if os.path.exists(dependency_path):
             dependencies.append(dependency_path)
 

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -45,7 +45,7 @@ def detect_arch_dependencies(path):
         if not line.startswith(prefix):
             continue
         dependency_path = line[len(prefix):]
-        if os.path.exists(dependency_path):
+        if os.path.exists(dependency_path) and not os.path.isdir(dependency_path):
             dependencies.append(dependency_path)
 
     return dependencies
@@ -76,7 +76,7 @@ def detect_debian_dependencies(path):
     stdout, stderr = process.communicate()
     dependencies = []
     for dependency_path in stdout.decode('utf-8').split('\n'):
-        if os.path.exists(dependency_path):
+        if os.path.exists(dependency_path) and not os.path.isdir(dependency_path):
             dependencies.append(dependency_path)
 
     return dependencies
@@ -99,7 +99,7 @@ def detect_redhat_dependencies(path):
     stdout, stderr = process.communicate()
     dependencies = []
     for dependency_path in stdout.decode('utf-8').split('\n'):
-        if os.path.exists(dependency_path):
+        if os.path.exists(dependency_path) and not os.path.isdir(dependency_path):
             dependencies.append(dependency_path)
 
     return dependencies

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from exodus_bundler.bundling import resolve_binary
+from exodus_bundler.launchers import find_executable
 
 
 def detect_dependencies(path):
@@ -26,7 +26,7 @@ def detect_arch_dependencies(path):
     if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
         return None
 
-    pacman = resolve_binary('pacman')
+    pacman = find_executable('pacman')
     if not pacman:
         return None
 
@@ -56,7 +56,7 @@ def detect_debian_dependencies(path):
     if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
         return None
 
-    dpkg = resolve_binary('dpkg')
+    dpkg = find_executable('dpkg')
     if not dpkg:
         return None
 
@@ -67,7 +67,7 @@ def detect_debian_dependencies(path):
         return None
 
     package_name = parts[0]
-    dpkg_query = resolve_binary('dpkg-query')
+    dpkg_query = find_executable('dpkg-query')
     if not dpkg_query:
         return None
 
@@ -87,7 +87,7 @@ def detect_redhat_dependencies(path):
     if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
         return None
 
-    rpm = resolve_binary('rpm')
+    rpm = find_executable('rpm')
     if not rpm:
         return None
 

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+
+from exodus_bundler.bundling import resolve_binary
+
+
+def detect_dependencies(path):
+    # We'll go through the supported systems one by one.
+    dependencies = detect_arch_dependencies(path)
+    if dependencies:
+        return dependencies
+
+    return None
+
+
+def detect_arch_dependencies(path):
+    cache_directory = '/var/cache/pacman'
+    if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
+        return None
+
+    pacman = resolve_binary('pacman')
+    if not pacman:
+        return None
+
+    process = subprocess.Popen(['pacman', '-Qo', path], stdout=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    parts = stdout.decode('utf-8').split(' is owned by ')
+    if len(parts) != 2:
+        return None
+
+    package_name = parts[1].split(' ')[0]
+    process = subprocess.Popen(['pacman', '-Ql', package_name], stdout=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    dependencies = []
+    for line in stdout.decode('utf-8').split('\n'):
+        prefix = '%s ' % package_name
+        if not line.startswith(prefix):
+            continue
+        dependency_path = line[len(prefix):]
+        if os.path.exists(dependency_path):
+            dependencies.append(dependency_path)
+
+    return dependencies

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -93,7 +93,7 @@ def detect_redhat_dependencies(path):
 
     process = subprocess.Popen([rpm, '-qf', path], stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()
-    package_name = stdout.decode('utf-8').split(': ')
+    package_name = stdout.decode('utf-8').strip()
 
     process = subprocess.Popen([rpm, '-ql', package_name], stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -22,14 +22,14 @@ def detect_arch_dependencies(path):
     if not pacman:
         return None
 
-    process = subprocess.Popen(['pacman', '-Qo', path], stdout=subprocess.PIPE)
+    process = subprocess.Popen([pacman, '-Qo', path], stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()
     parts = stdout.decode('utf-8').split(' is owned by ')
     if len(parts) != 2:
         return None
 
     package_name = parts[1].split(' ')[0]
-    process = subprocess.Popen(['pacman', '-Ql', package_name], stdout=subprocess.PIPE)
+    process = subprocess.Popen([pacman, '-Ql', package_name], stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()
     dependencies = []
     for line in stdout.decode('utf-8').split('\n'):

--- a/src/exodus_bundler/errors.py
+++ b/src/exodus_bundler/errors.py
@@ -3,6 +3,11 @@ class FatalError(Exception):
     pass
 
 
+class DependencyDetectionError(FatalError):
+    """Signifies that the dependency detection process failed."""
+    pass
+
+
 class InvalidElfBinaryError(FatalError):
     """Signifies that a file was expected to be an ELF binary, but wasn't."""
     pass

--- a/tests/test_bundling.py
+++ b/tests/test_bundling.py
@@ -140,6 +140,28 @@ def test_create_unpackaged_bundle(fizz_buzz, shell_launchers):
         shutil.rmtree(root_directory)
 
 
+@pytest.mark.parametrize('detect', [False, True])
+def test_create_unpackaged_bundle_detects_dependencies(detect):
+    binary_name = 'ls'
+    root_directory = create_unpackaged_bundle(
+        rename=[], executables=[binary_name], detect=detect)
+    try:
+        # Determine the bundle root.
+        binary_symlink = os.path.join(root_directory, 'bin', binary_name)
+        binary_path = os.path.realpath(binary_symlink)
+        dirname, basename = os.path.split(binary_path)
+        while len(basename) != 64:
+            dirname, basename = os.path.split(dirname)
+        bundle_root = os.path.join(dirname, basename)
+
+        man_directory = os.path.join(bundle_root, 'usr', 'share', 'man')
+        assert os.path.exists(man_directory) == detect, \
+            'The man directory should only exist when `detect=True`.'
+    finally:
+        assert root_directory.startswith('/tmp/')
+        shutil.rmtree(root_directory)
+
+
 def test_create_unpackaged_bundle_has_correct_args():
     root_directory = create_unpackaged_bundle(
         rename=[], executables=[echo_args_glibc_32], chroot=chroot)

--- a/tests/test_dependency_detection.py
+++ b/tests/test_dependency_detection.py
@@ -1,3 +1,5 @@
+import os
+
 from exodus_bundler.dependency_detection import detect_dependencies
 
 
@@ -6,7 +8,7 @@ def test_detect_dependencies():
     ls = '/usr/bin/ls'
     if not os.path.exists(ls):
         ls = '/bin/ls'
-    assert os.path.exists(ls), 'This test assumes that `ls` is installed on the system.'`
+    assert os.path.exists(ls), 'This test assumes that `ls` is installed on the system.'
 
     dependencies = detect_dependencies('/usr/bin/ls')
     print(dependencies)

--- a/tests/test_dependency_detection.py
+++ b/tests/test_dependency_detection.py
@@ -10,7 +10,7 @@ def test_detect_dependencies():
         ls = '/bin/ls'
     assert os.path.exists(ls), 'This test assumes that `ls` is installed on the system.'
 
-    dependencies = detect_dependencies('/usr/bin/ls')
+    dependencies = detect_dependencies(ls)
     print(dependencies)
     assert any(ls in dependency for dependency in dependencies), \
         '`%s` should have been detected as a dependency for `ls`.' % ls

--- a/tests/test_dependency_detection.py
+++ b/tests/test_dependency_detection.py
@@ -1,0 +1,8 @@
+from exodus_bundler.dependency_detection import detect_dependencies
+
+
+def test_detect_dependencies():
+    dependencies = detect_dependencies('/usr/bin/ls')
+    print(dependencies)
+    assert any('/usr/bin/ls' in dependency for dependency in dependencies), \
+        '`/usr/bin/ls` should have been detected as a dependency for `ls`.'

--- a/tests/test_dependency_detection.py
+++ b/tests/test_dependency_detection.py
@@ -2,7 +2,13 @@ from exodus_bundler.dependency_detection import detect_dependencies
 
 
 def test_detect_dependencies():
+    # This is a little janky, but the test suite won't run anywhere where it's not true.
+    ls = '/usr/bin/ls'
+    if not os.path.exists(ls):
+        ls = '/bin/ls'
+    assert os.path.exists(ls), 'This test assumes that `ls` is installed on the system.'`
+
     dependencies = detect_dependencies('/usr/bin/ls')
     print(dependencies)
-    assert any('/usr/bin/ls' in dependency for dependency in dependencies), \
-        '`/usr/bin/ls` should have been detected as a dependency for `ls`.'
+    assert any(ls in dependency for dependency in dependencies), \
+        '`%s` should have been detected as a dependency for `ls`.' % ls


### PR DESCRIPTION
This only supports Arch, Debian/Ubuntu, and RHEL/CentOS right now, but it should be easy to add support for other package managers in the future.
