### PR TITLE
Clean up the dependency detection code

### DIFF
--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -4,6 +4,29 @@ import subprocess
 from exodus_bundler.launchers import find_executable
 
 
+class PackageManager(object):
+    """Base class representing a package manager.
+
+    The class level attributes can be overwritten in derived classes to customize the behavior.
+
+    Attributes:
+        cache_directory (str): The location of the system's package cache.
+        name (str): The name of the package manager executable.
+    """
+    cache_directory = None
+    name = None
+
+    @property
+    def cache_exists(self):
+        """Whether or not the expected package cache directory exists."""
+        return os.path.exists(self.cache_directory) and os.path.isdir(self.cache_directory)
+
+    @property
+    def executable(self):
+        """The full path to the package manager's executable entry point."""
+        return find_executable(self.name)
+
+
 def detect_dependencies(path):
     # We'll go through the supported systems one by one.
     dependencies = detect_arch_dependencies(path)

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -85,6 +85,14 @@ class Pacman(PackageManager):
     owner_regex = ' is owned by (.*)\s+.*'
 
 
+class Yum(PackageManager):
+    cache_directory = '/var/cache/yum'
+    list_command = ['rpm', '-ql']
+    list_regex = '(.+)'
+    owner_command = ['rpm', '-qf']
+    owner_regex = '(.+)'
+
+
 def detect_dependencies(path):
     # We'll go through the supported systems one by one.
     dependencies = detect_arch_dependencies(path)
@@ -113,23 +121,5 @@ def detect_debian_dependencies(path):
 
 
 def detect_redhat_dependencies(path):
-    cache_directory = '/var/cache/yum'
-    if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
-        return None
-
-    rpm = find_executable('rpm')
-    if not rpm:
-        return None
-
-    process = subprocess.Popen([rpm, '-qf', path], stdout=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    package_name = stdout.decode('utf-8').strip()
-
-    process = subprocess.Popen([rpm, '-ql', package_name], stdout=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    dependencies = []
-    for dependency_path in stdout.decode('utf-8').split('\n'):
-        if os.path.exists(dependency_path) and not os.path.isdir(dependency_path):
-            dependencies.append(dependency_path)
-
-    return dependencies
+    yum = Yum()
+    return yum.find_dependencies(path)

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -69,6 +69,14 @@ class PackageManager(object):
         return all(find_executable(command) is not None for command in commands)
 
 
+class Pacman(PackageManager):
+    cache_directory = '/var/cache/pacman'
+    list_command = ['pacman', '-Ql']
+    list_regex = '.*\s+(\/.+)'
+    owner_command = ['pacman', '-Qo']
+    owner_regex = ' is owned by (.*)\s+.*'
+
+
 def detect_dependencies(path):
     # We'll go through the supported systems one by one.
     dependencies = detect_arch_dependencies(path)
@@ -87,33 +95,8 @@ def detect_dependencies(path):
 
 
 def detect_arch_dependencies(path):
-    cache_directory = '/var/cache/pacman'
-    if not (os.path.exists(cache_directory) and os.path.isdir(cache_directory)):
-        return None
-
-    pacman = find_executable('pacman')
-    if not pacman:
-        return None
-
-    process = subprocess.Popen([pacman, '-Qo', path], stdout=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    parts = stdout.decode('utf-8').split(' is owned by ')
-    if len(parts) != 2:
-        return None
-
-    package_name = parts[1].split(' ')[0]
-    process = subprocess.Popen([pacman, '-Ql', package_name], stdout=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    dependencies = []
-    for line in stdout.decode('utf-8').split('\n'):
-        prefix = '%s ' % package_name
-        if not line.startswith(prefix):
-            continue
-        dependency_path = line[len(prefix):]
-        if os.path.exists(dependency_path) and not os.path.isdir(dependency_path):
-            dependencies.append(dependency_path)
-
-    return dependencies
+    pacman = Pacman()
+    return pacman.find_dependencies(path)
 
 
 def detect_debian_dependencies(path):

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -93,33 +93,18 @@ class Yum(PackageManager):
     owner_regex = '(.+)'
 
 
+package_managers = [
+    Apt(),
+    Pacman(),
+    Yum(),
+]
+
+
 def detect_dependencies(path):
     # We'll go through the supported systems one by one.
-    dependencies = detect_arch_dependencies(path)
-    if dependencies:
-        return dependencies
-
-    dependencies = detect_debian_dependencies(path)
-    if dependencies:
-        return dependencies
-
-    dependencies = detect_redhat_dependencies(path)
-    if dependencies:
-        return dependencies
+    for package_manager in package_managers:
+        dependencies = package_manager.find_dependencies(path)
+        if dependencies:
+            return dependencies
 
     return None
-
-
-def detect_arch_dependencies(path):
-    pacman = Pacman()
-    return pacman.find_dependencies(path)
-
-
-def detect_debian_dependencies(path):
-    apt = Apt()
-    return apt.find_dependencies(path)
-
-
-def detect_redhat_dependencies(path):
-    yum = Yum()
-    return yum.find_dependencies(path)

--- a/tests/test_dependency_detection.py
+++ b/tests/test_dependency_detection.py
@@ -11,6 +11,5 @@ def test_detect_dependencies():
     assert os.path.exists(ls), 'This test assumes that `ls` is installed on the system.'
 
     dependencies = detect_dependencies(ls)
-    print(dependencies)
     assert any(ls in dependency for dependency in dependencies), \
         '`%s` should have been detected as a dependency for `ls`.' % ls


### PR DESCRIPTION
This just extracts out some of the common logic and makes the configuration for different systems more declarative. This should make it much easier to add support for other package managers.
