### PR TITLE
Add explicit errors for unsupported architectures

### DIFF
--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -20,6 +20,7 @@ from exodus_bundler.errors import DependencyDetectionError
 from exodus_bundler.errors import InvalidElfBinaryError
 from exodus_bundler.errors import MissingFileError
 from exodus_bundler.errors import UnexpectedDirectoryError
+from exodus_bundler.errors import UnsupportedArchitectureError
 from exodus_bundler.launchers import CompilerNotFoundError
 from exodus_bundler.launchers import construct_bash_launcher
 from exodus_bundler.launchers import construct_binary_launcher
@@ -267,7 +268,14 @@ class Elf(object):
 
             # Determine whether this is a 32-bit or 64-bit file.
             format_byte = f.read(1)
-            self.bits = {b'\x01': 32, b'\x02': 64}[format_byte]
+            self.bits = {b'\x01': 32, b'\x02': 64}.get(format_byte)
+            if not self.bits:
+                raise UnsupportedArchitectureError(
+                    ('The "%s" file does not appear to be either 32 or 64 bits. ' % path) +
+                    'Other architectures are not currently supported, but you can open an '
+                    'issue at https://github.com/intoli/exodus stating your use-case and '
+                    'support might get extended in the future.',
+                )
 
             # Determine whether it's big or little endian and construct an integer parsing function.
             endian_byte = f.read(1)

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -281,6 +281,13 @@ class Elf(object):
             endian_byte = f.read(1)
             byteorder = {b'\x01': 'little', b'\x02': 'big'}[endian_byte]
             assert byteorder == 'little', 'Big endian is not supported right now.'
+            if not byteorder:
+                raise UnsupportedArchitectureError(
+                    ('The "%s" file does not appear to be little endian, ' % path) +
+                    'and big endian binaries are not currently supported. You can open an '
+                    'issue at https://github.com/intoli/exodus stating your use-case and '
+                    'support might get extended in the future.',
+                )
 
             def hex(bytes):
                 return bytes_to_int(bytes, byteorder=byteorder)

--- a/src/exodus_bundler/errors.py
+++ b/src/exodus_bundler/errors.py
@@ -21,3 +21,8 @@ class MissingFileError(FatalError):
 class UnexpectedDirectoryError(FatalError):
     """Signifies that a path was unexpectedly a directory."""
     pass
+
+
+class UnsupportedArchitectureError(FatalError):
+    """Signifies that a binary has an unexpected architecture."""
+    pass


### PR DESCRIPTION
There were already assertions here, but not fatal errors will be thrown with more informative error messages. The messages also ask people to open an issue if they have a use case outside of the supported architectures.
