### PR TITLE
Use a default linker when determining the dependencies of manually added libraries

### DIFF
--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -686,7 +686,7 @@ class Bundle(object):
 
     Attributes:
         chroot (str): The root directory used when invoking the linker (or `None` for `/`).
-        files (:obj:`list` of :obj:`File`): The files to be included in the bundle.
+        files (:obj:`set` of :obj:`File`): The files to be included in the bundle.
         working_directory (str): The root directory where the bundles will be written and packaged.
     """
     def __init__(self, working_directory=None, chroot=None):


### PR DESCRIPTION
This makes `Bundle` instances keep track of the linkers that they've encountered in program headers, and uses the observed linker to find the dependencies of manually added ELF binaries. We can try to improve the error handling here for situations where there are multiple linkers in the future, but this should cover the vast majority of use cases.

Closes #46
