### PR TITLE
Use 'C' locale for dependency detection subprocess

### DIFF
--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -50,7 +50,9 @@ class PackageManager(object):
         if not self.cache_exists or not self.commands_exist:
             return None
         args = self.owner_command + [path]
-        process = subprocess.Popen(args, stdout=subprocess.PIPE)
+        env = os.environ.copy()
+        env['LC_ALL'] = 'C'
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, env=env)
         stdout, stderr = process.communicate()
         output = stdout.decode('utf-8').strip()
         match = re.search(self.owner_regex, output)


### PR DESCRIPTION
Fixes parsing for localized output.

Otherwise the parsing regex doesn't match output on localized Arch installations (in my case):

```
pacman -Qo /usr/bin/emacs
/usr/bin/emacs ist in emacs 26.1-1 enthalten
```
