### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ optional arguments:
   -c CHROOT_PATH, --chroot CHROOT_PATH
                         A directory that will be treated as the root during
                         linking. Useful for testing and bundling extracted
-                        packages that won run without a chroot. (default:
+                        packages that won't run without a chroot. (default:
                         None)
   -a DEPENDENCY, --add DEPENDENCY, --additional-file DEPENDENCY
                         Specifies an additional file to include in the bundle,


### PR DESCRIPTION
`won` -> `won't`

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://www.clahub.com/agreements/intoli/exodus)
