### PR TITLE
docs: fix simple typo, decoratator -> decorator

### DIFF
--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -224,7 +224,7 @@ def run_ldd(ldd, binary):
 
 
 class stored_property(object):
-    """Simple decoratator for a class property that will be cached indefinitely."""
+    """Simple decorator for a class property that will be cached indefinitely."""
     def __init__(self, function):
         self.__doc__ = getattr(function, '__doc__')
         self.function = function


### PR DESCRIPTION
There is a small typo in src/exodus_bundler/bundling.py.

Should read `decorator` rather than `decoratator`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md