### PR TITLE
Update the CLA provider

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,0 +1,6 @@
+{
+  "contributors": [
+    "sangaline"
+  ],
+  "message": "Thank you for making a contribution! We require new contributors to sign our [Contributor License Agreement (CLA)](https://github.com/intoli/exodus/blob/master/CLA.md). Please review our [Contributing Guide](https://github.com/intoli/exodus/blob/master/CONTRIBUTING.md) and make sure that you've followed the steps listed there."
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
-- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://www.clahub.com/agreements/intoli/exodus)
+*Replace this with the pull request description...*
+
+
+**Please check the boxes below to confirm that you have completed these steps:**
+
+* [ ] I have read and followed the [Contribution Agreement](https://github.com/intoli/exodus/blob/master/CONTRIBUTING.md).
+* [ ] I have signed the project [Contributor License Agreement](https://github.com/intoli/exodus/blob/master/CONTRIBUTING.md).
+
 
 *Replace this text with either "Closes #N" or "Connects #N," where N is the corresponding GitHub issue number.*

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,123 @@
+## Contributor Agreement
+
+## Individual Contributor Exclusive License Agreement
+
+## (including the Traditional Patent License OPTION)
+
+Thank you for your interest in contributing to Intoli, LLC's Exodus ("We" or "Us").
+
+The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us. To make this document effective, please follow the instructions at https://github.com/intoli/exodus/blob/master/CONTRIBUTING.md.
+
+### How to use this Contributor Agreement
+
+If You are an employee and have created the Contribution as part of your employment, You need to have Your employer approve this Agreement or sign the Entity version of this document. If You do not own the Copyright in the entire work of authorship, any other author of the Contribution should also sign this – in any event, please contact Us at open-source@intoli.com
+
+### 1\. Definitions
+
+**"You"** means the individual Copyright owner who Submits a Contribution to Us.
+
+**"Legal Entity"** means an entity that is not a natural person.
+
+**"Affiliate"** means any other Legal Entity that controls, is controlled by, or under common control with that Legal Entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such Legal Entity, whether by contract or otherwise, (ii) ownership of fifty percent (50%) or more of the outstanding shares or securities that vote to elect the management or other persons who direct such Legal Entity or (iii) beneficial ownership of such entity.
+
+**"Contribution"** means any original work of authorship, including any original modifications or additions to an existing work of authorship, Submitted by You to Us, in which You own the Copyright.
+
+**"Copyright"** means all rights protecting works of authorship, including copyright, moral and neighboring rights, as appropriate, for the full term of their existence.
+
+**"Material"** means the software or documentation made available by Us to third parties. When this Agreement covers more than one software project, the Material means the software or documentation to which the Contribution was Submitted. After You Submit the Contribution, it may be included in the Material.
+
+**"Submit"** means any act by which a Contribution is transferred to Us by You by means of tangible or intangible media, including but not limited to electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us, but excluding any transfer that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+**"Documentation"** means any non-software portion of a Contribution.
+
+### 2\. License grant
+
+#### 2.1 Copyright license to Us
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us a worldwide, royalty-free, Exclusive, perpetual and irrevocable (except as stated in Section 8.2) license, with the right to transfer an unlimited number of non-exclusive licenses or to grant sublicenses to third parties, under the Copyright covering the Contribution to use the Contribution by all means, including, but not limited to:
+
+*   publish the Contribution,
+*   modify the Contribution,
+*   prepare derivative works based upon or containing the Contribution and/or to combine the Contribution with other Materials,
+*   reproduce the Contribution in original or modified form,
+*   distribute, to make the Contribution available to the public, display and publicly perform the Contribution in original or modified form.
+
+#### 2.2 Moral rights
+
+Moral Rights remain unaffected to the extent they are recognized and not waivable by applicable law. Notwithstanding, You may add your name to the attribution mechanism customary used in the Materials you Contribute to, such as the header of the source code files of Your Contribution, and We will respect this attribution when using Your Contribution.
+
+#### 2.3 Copyright license back to You
+
+Upon such grant of rights to Us, We immediately grant to You a worldwide, royalty-free, non-exclusive, perpetual and irrevocable license, with the right to transfer an unlimited number of non-exclusive licenses or to grant sublicenses to third parties, under the Copyright covering the Contribution to use the Contribution by all means, including, but not limited to:
+
+*   publish the Contribution,
+*   modify the Contribution,
+*   prepare derivative works based upon or containing the Contribution and/or to combine the Contribution with other Materials,
+*   reproduce the Contribution in original or modified form,
+*   distribute, to make the Contribution available to the public, display and publicly perform the Contribution in original or modified form.
+
+This license back is limited to the Contribution and does not provide any rights to the Material.
+
+### 3\. Patents
+
+#### 3.1 Patent license
+
+Subject to the terms and conditions of this Agreement You hereby grant to Us and to recipients of Materials distributed by Us a worldwide, royalty-free, non-exclusive, perpetual and irrevocable (except as stated in Section 3.2) patent license, with the right to transfer an unlimited number of non-exclusive licenses or to grant sublicenses to third parties, to make, have made, use, sell, offer for sale, import and otherwise transfer the Contribution and the Contribution in combination with any Material (and portions of such combination). This license applies to all patents owned or controlled by You, whether already acquired or hereafter acquired, that would be infringed by making, having made, using, selling, offering for sale, importing or otherwise transferring of Your Contribution(s) alone or by combination of Your Contribution(s) with any Material.
+
+#### 3.2 Revocation of patent license
+
+You reserve the right to revoke the patent license stated in section 3.1 if We make any infringement claim that is targeted at your Contribution and not asserted for a Defensive Purpose. An assertion of claims of the Patents shall be considered for a "Defensive Purpose" if the claims are asserted against an entity that has filed, maintained, threatened, or voluntarily participated in a patent infringement lawsuit against Us or any of Our licensees.
+
+### 4. Disclaimer
+
+THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN DURATION AND EXTENT TO THE MINIMUM PERIOD AND EXTENT PERMITTED BY LAW.
+
+### 5. Consequential damage waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR WE BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+### 6. Approximation of disclaimer and damage waiver
+
+IF THE DISCLAIMER AND DAMAGE WAIVER MENTIONED IN SECTION 4. AND SECTION 5. CANNOT BE GIVEN LEGAL EFFECT UNDER APPLICABLE LOCAL LAW, REVIEWING COURTS SHALL APPLY LOCAL LAW THAT MOST CLOSELY APPROXIMATES AN ABSOLUTE WAIVER OF ALL CIVIL OR CONTRACTUAL LIABILITY IN CONNECTION WITH THE CONTRIBUTION.
+
+### 7. Term
+
+7.1 This Agreement shall come into effect upon Your acceptance of the terms and conditions.
+
+7.3 In the event of a termination of this Agreement Sections 4, 5, 6, 7 and 8 shall survive such termination and shall remain in full force thereafter. For the avoidance of doubt, Free and Open Source Software (sub)licenses that have already been granted for Contributions at the date of the termination shall remain in full force after the termination of this Agreement.
+
+### 8 Miscellaneous
+
+8.1 This Agreement and all disputes, claims, actions, suits or other proceedings arising out of this agreement or relating in any way to it shall be governed by the laws of United States excluding its private international law provisions.
+
+8.2 This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and overrides all other agreements or understandings.
+
+8.3 In case of Your death, this agreement shall continue with Your heirs. In case of more than one heir, all heirs must exercise their rights through a commonly authorized person.
+
+8.4 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and that is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.
+
+8.5 You agree to notify Us of any facts or circumstances of which you become aware that would make this Agreement inaccurate in any respect.
+
+### You
+
+Date:
+
+Name:
+
+Title:
+
+Address:
+
+### Us
+
+Date:
+
+Name:
+
+Title:
+
+Address:
+
+#### Recreate this Contributor License Agreement
+
+[https://contributoragreements.org/ca-cla-chooser/?beneficiary-name=Intoli%2C+LLC&project-name=Exodus&project-website=https%3A%2F%2Fgithub.com%2Fintoli%2Fexodus&project-email=open-source%40intoli.com&process-url=https%3A%2F%2Fgithub.com%2Fintoli%2Fexodus%2Fblob%2Fmaster%2FCONTRIBUTING.md&project-jurisdiction=United+States&agreement-exclusivity=exclusive&fsfe-compliance=&fsfe-fla=&outbound-option=no-commitment&outboundlist=&outboundlist-custom=&medialist=\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_&patent-option=Traditional&your-date=&your-name=&your-title=&your-address=&your-patents=&pos=apply&action=](https://contributoragreements.org/ca-cla-chooser/?beneficiary-name=Intoli%2C+LLC&project-name=Exodus&project-website=https%3A%2F%2Fgithub.com%2Fintoli%2Fexodus&project-email=open-source%40intoli.com&process-url=https%3A%2F%2Fgithub.com%2Fintoli%2Fexodus%2Fblob%2Fmaster%2FCONTRIBUTING.md&project-jurisdiction=United+States&agreement-exclusivity=exclusive&fsfe-compliance=&fsfe-fla=&outbound-option=no-commitment&outboundlist=&outboundlist-custom=&medialist=____________________&patent-option=Traditional&your-date=&your-name=&your-title=&your-address=&your-patents=&pos=apply&action=)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ Contributions are welcome, but please follow these contributor guidelines:
 - Create an issue on [the issue tracker](https://github.com/intoli/exodus/issues/new) to discuss potential changes before submitting a pull request.
 - Include at least one test to cover any new functionality or bug fixes.
 - Make sure that all of your tests are passing and that there are no merge conflicts.
-- You agree to sign the project's [Contributor License Agreement](https://www.clahub.com/agreements/intoli/exodus).
+- Print, sign, and email the [Contributor License Agreement](https://github.com/intoli/exodus/blob/master/CLA.md) to [open-source@intoli.com](mailto:open-source@intoli.com).


### PR DESCRIPTION
We had previously used [clahub](https://github.com/clahub/clahub) to manage our CLA, but they recently shutdown. This PR adds a `CLA.md` file to the project generated from https://contributoragreements.org and switches over the compliance check to [CLA-Bot](https://colineberhardt.github.io/cla-bot/).
