### PR TITLE
Verify support for Python 3.9 and fix CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/exodus
   docker:
-    - image: circleci/python:3.6.1
+    - image: circleci/python:3.9-buster
 
 
 version: 2
@@ -90,7 +90,7 @@ jobs:
             )
             sudo cp exodus.c /
             cd /
-            sudo musl-gcc -static -O3 exodus.c -o exodus
+            sudo gcc -O3 exodus.c -o exodus
             sudo chmod a+x /exodus
 
             sudo mv /etc/ld.so.cache /tmp/ld.so.cache.bck

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ graft .circleci
 graft .github
 
 include .bumpversion.cfg
+include .clabot
 include .coveragerc
 include conftest.py
 include development-requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: System :: Archiving :: Packaging',

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -591,7 +591,7 @@ class File(object):
                 f.write(launcher_content)
         except CompilerNotFoundError:
             if not shell_launcher:
-                logger.warn((
+                logger.warning((
                     'Installing either the musl or diet C libraries will result in more efficient '
                     'launchers (currently using bash fallbacks instead).'
                 ))
@@ -752,7 +752,7 @@ class Bundle(object):
                     # We definitely don't want a launcher for this file, so clear the linker.
                     file.elf.linker_file = None
                 else:
-                    logger.warn((
+                    logger.warning((
                         'An ELF binary without a suitable linker candidate was encountered. '
                         'Either no linker was found or there are multiple conflicting linkers.'
                     ))

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -169,12 +169,12 @@ def parse_dependencies_from_ldd_output(content):
     dependencies = []
     for line in content:
         # This first one is a special case of invoking the linker as `ldd`.
-        if re.search('^\s*(/.*?)\s*=>\s*ldd\s*\(', line):
+        if re.search(r'^\s*(/.*?)\s*=>\s*ldd\s*\(', line):
             # We'll exclude this because it's the hardcoded INTERP path, and it would be
             # impossible to get the full path from this command output.
             continue
-        match = re.search('=>\s*(/.*?)\s*\(', line)
-        match = match or re.search('\s*(/.*?)\s*\(', line)
+        match = re.search(r'=>\s*(/.*?)\s*\(', line)
+        match = match or re.search(r'\s*(/.*?)\s*\(', line)
         if match:
             dependencies.append(match.group(1))
 
@@ -673,7 +673,7 @@ class File(object):
             return False
 
         # Most libraries will include `.so` in the filename.
-        return re.search('\.so(?:\.|$)', self.path)
+        return re.search(r'\.so(?:\.|$)', self.path)
 
     @stored_property
     def source(self):

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -124,7 +124,7 @@ def create_unpackaged_bundle(executables, rename=[], chroot=None, add=[], no_sym
                         ('Automatic dependency detection failed. Either "%s" ' % file.path) +
                         'is not tracked by your package manager, or your operating system '
                         'is not currently compatible with the `--detect` option. If not, please '
-                        'create an issue at https://github.com/intoli/exodus and we\'ll try our '
+                        "create an issue at https://github.com/intoli/exodus and we'll try our "
                         ' to add support for it in the future.',
                     )
 
@@ -731,7 +731,7 @@ class Bundle(object):
         try:
             file = self.file_factory(path, entry_point=entry_point, chroot=self.chroot)
         except UnexpectedDirectoryError:
-            assert entry_point is None, 'Directories can\'t have entry points.'
+            assert entry_point is None, "Directories can't have entry points."
             for root, directories, files in os.walk(path):
                 for file in files:
                     file_path = os.path.join(root, file)
@@ -853,12 +853,12 @@ class Bundle(object):
         file = next((file for file in self.files if file.path == path), None)
         if file is not None:
             assert entry_point == file.entry_point or not entry_point or not file.entry_point, \
-                'The entry point property should always persist, but can\'t conflict.'
+                "The entry point property should always persist, but can't conflict."
             file.entry_point = file.entry_point or entry_point
             assert chroot == file.chroot, 'The chroot must match.'
             file.library = file.library or library
             assert not file.entry_point or not file.library, \
-                'A file can\'t be both an entry point and a library.'
+                "A file can't be both an entry point and a library."
             return file
 
         return File(path, entry_point, chroot, library, file_factory)

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -82,17 +82,17 @@ class Apt(PackageManager):
 class Pacman(PackageManager):
     cache_directory = '/var/cache/pacman'
     list_command = ['pacman', '-Ql']
-    list_regex = '.*\s+(\/.+)'
+    list_regex = r'.*\s+(\/.+)'
     owner_command = ['pacman', '-Qo']
-    owner_regex = ' is owned by (.*)\s+.*'
+    owner_regex = r' is owned by (.*)\s+.*'
 
 
 class Yum(PackageManager):
     cache_directory = '/var/cache/yum'
     list_command = ['rpm', '-ql']
-    list_regex = '(.+)'
+    list_regex = r'(.+)'
     owner_command = ['rpm', '-qf']
-    owner_regex = '(.+)'
+    owner_regex = r'(.+)'
 
 
 package_managers = [

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -103,7 +103,7 @@ def extract_paths(content, existing_only=True):
 
 def strip_pid_prefix(line):
     """Strips out the `[pid XXX] ` prefix if present."""
-    match = re.match('\[pid\s+\d+\]\s*', line)
+    match = re.match(r'\[pid\s+\d+\]\s*', line)
     if match:
         return line[len(match.group()):]
     return line

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,7 @@ def test_logging_outputs(capsys):
     # The different levels should be routed separately to stdout/stderr.
     configure_logging(verbose=True, quiet=False)
     logger.debug('debug')
-    logger.warn('warn')
+    logger.warning('warn')
     logger.info('info')
     logger.error('error')
     out, err = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_adding_additional_files(capsys):
     args = ['--chroot', chroot, '--output', '-', '--tarball', fizz_buzz_glibc_32]
     stdin = '\n'.join((fizz_buzz_glibc_32_exe, fizz_buzz_glibc_64))
     returncode, stdout, stderr = run_exodus(args, universal_newlines=False, stdin=stdin)
-    assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+    assert returncode == 0, "Exodus should have exited with a success status code, but didn't."
     stream = io.BytesIO(stdout)
     with tarfile.open(fileobj=stream, mode='r:gz') as f:
         names = f.getnames()
@@ -107,7 +107,7 @@ def test_writing_bundle_to_disk():
     args = ['--chroot', chroot, '--output', filename, fizz_buzz_glibc_32]
     try:
         returncode, stdout, stderr = run_exodus(args)
-        assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+        assert returncode == 0, "Exodus should have exited with a success status code, but didn't."
         with open(filename, 'rb') as f_in:
             first_line = f_in.readline().strip()
         assert first_line == b'#! /bin/bash', stderr
@@ -119,7 +119,7 @@ def test_writing_bundle_to_disk():
 def test_writing_bundle_to_stdout():
     args = ['--chroot', chroot, '--output', '-', fizz_buzz_glibc_32]
     returncode, stdout, stderr = run_exodus(args)
-    assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+    assert returncode == 0, "Exodus should have exited with a success status code, but didn't."
     assert stdout.startswith('#! /bin/sh'), stderr
 
 
@@ -129,7 +129,7 @@ def test_writing_tarball_to_disk():
     args = ['--chroot', chroot, '--output', filename, '--tarball', fizz_buzz_glibc_32]
     try:
         returncode, stdout, stderr = run_exodus(args)
-        assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+        assert returncode == 0, "Exodus should have exited with a success status code, but didn't."
         assert tarfile.is_tarfile(filename), stderr
         with tarfile.open(filename, mode='r:gz') as f_in:
             assert 'exodus/bin/fizz-buzz-glibc-32' in f_in.getnames()
@@ -141,7 +141,7 @@ def test_writing_tarball_to_disk():
 def test_writing_tarball_to_stdout():
     args = ['--chroot', chroot, '--output', '-', '--tarball', fizz_buzz_glibc_32]
     returncode, stdout, stderr = run_exodus(args, universal_newlines=False)
-    assert returncode == 0, 'Exodus should have exited with a success status code, but didn\'t.'
+    assert returncode == 0, "Exodus should have exited with a success status code, but didn't."
     stream = io.BytesIO(stdout)
     with tarfile.open(fileobj=stream, mode='r:gz') as f:
         assert 'exodus/bin/fizz-buzz-glibc-32' in f.getnames(), stderr

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,13 @@
 envlist =
     clean,
     check,
-    {py27,py36},
+    {py27,py39},
     report,
 
 [testenv]
 basepython =
     py27: {env:TOXPYTHON:python2.7}
-    {clean,check,report,py36}: {env:TOXPYTHON:python3.6}
+    {clean,check,report,py39}: {env:TOXPYTHON:python3.9}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ commands =
 deps = coverage
 skip_install = true
 commands =
-    coverage combine --append
     coverage report
     coverage html
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,6 @@ commands =
 commands = coverage erase
 skip_install = true
 deps = coverage
+
+[flake8]
+ignore = E128,W504


### PR DESCRIPTION
CI had been failing due to newer flake8 versions having different default rules, and also because of some weird behavior with the outdated strace version on the Debian 8 docker image that was being used for the build (it was printing out raw pointers instead of the actual string values). This updates the build image to use Debian 10 and Python 3.9, fixes the important flake8 linting issues, disables inconsequential flake8 rules, and updates the trove classifiers to include support for Python 3.8 and Python 3.9. I should follow up with some further CI improvements, but this at least gets things working again.
