### PR TITLE
Fix the total code coverage calculation

### DIFF
--- a/development-requirements.txt
+++ b/development-requirements.txt
@@ -1,5 +1,5 @@
 bumpversion==0.5.3
-coverage==4.4.2
+coverage>=5.4
 m2r>=0.1.12
 pluggy==0.5.2
 py==1.4.34

--- a/src/exodus_bundler/bundling.py
+++ b/src/exodus_bundler/bundling.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64
 import filecmp
 import hashlib

--- a/src/exodus_bundler/cli.py
+++ b/src/exodus_bundler/cli.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import argparse
 import logging
 import sys

--- a/src/exodus_bundler/dependency_detection.py
+++ b/src/exodus_bundler/dependency_detection.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import re
 import subprocess

--- a/src/exodus_bundler/errors.py
+++ b/src/exodus_bundler/errors.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 class FatalError(Exception):
     """Base class for exceptions that should terminate program execution."""
     pass

--- a/src/exodus_bundler/input_parsing.py
+++ b/src/exodus_bundler/input_parsing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import re
 

--- a/src/exodus_bundler/launchers.py
+++ b/src/exodus_bundler/launchers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Methods to produce launchers that will invoke the relocated executables with
 the proper linker and library paths."""
 import os

--- a/src/exodus_bundler/templating.py
+++ b/src/exodus_bundler/templating.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Contains a couple of fairly trivial templating methods used for constructing
 the loaders and the output filename. Any instances of {{variable_name}} will be
 replaced by the corresponding values."""

--- a/tests/test_bundling.py
+++ b/tests/test_bundling.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import shutil
 from subprocess import PIPE

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import io
 import os
 import subprocess

--- a/tests/test_dependency_detection.py
+++ b/tests/test_dependency_detection.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 
 from exodus_bundler.dependency_detection import detect_dependencies

--- a/tests/test_input_parsing.py
+++ b/tests/test_input_parsing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 
 from exodus_bundler.input_parsing import extract_exec_path

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import shutil
 import stat

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 
 from exodus_bundler.templating import render_template


### PR DESCRIPTION
This adds explicit UTF-8 encoding headers to all of the source files and bumps the coveragepy development dependency version from v4 to v5 for consistency with what runs inside of the tox environments. This resolves the unicode decoding errors that we were getting previously when producing `total-coverage.json` on CI.
