### PR TITLE
Make exodus work on python >=3.12 (distutils was removed)

### DIFF
--- a/src/exodus_bundler/launchers.py
+++ b/src/exodus_bundler/launchers.py
@@ -4,7 +4,7 @@ the proper linker and library paths."""
 import os
 import re
 import tempfile
-from distutils.spawn import find_executable as find_executable_original
+from shutil import which as find_executable_original
 from subprocess import PIPE
 from subprocess import Popen
 


### PR DESCRIPTION
One-line fix to make exodus work on Python versions 3.12 or greater.

I haven't signed the CLA, but I hereby release this fix as public domain if you want to use it and keep the copyright or whatever.  I just want exodus to work again.

Closes #79
